### PR TITLE
Don't propagate mutators returning false

### DIFF
--- a/flat_map.go
+++ b/flat_map.go
@@ -6,13 +6,17 @@ package channels
 // The output channel will have the same capacity as the input channel, and is
 // closed once the input channel is closed and all mapped values are pushed to
 // the output channel.
-func FlatMap[TIn any, TOut any, TOutSlice []TOut](inc <-chan TIn, mapFn func(TIn) TOutSlice) <-chan TOut {
+func FlatMap[TIn any, TOut any, TOutSlice []TOut](inc <-chan TIn, mapFn func(TIn) (TOutSlice, bool)) <-chan TOut {
 	outc := make(chan TOut, cap(inc))
 
 	go func() {
 		defer close(outc)
 		for in := range inc {
-			outSlice := mapFn(in)
+			outSlice, ok := mapFn(in)
+			if !ok {
+				continue
+			}
+
 			for _, out := range outSlice {
 				outc <- out
 			}
@@ -25,7 +29,7 @@ func FlatMap[TIn any, TOut any, TOutSlice []TOut](inc <-chan TIn, mapFn func(TIn
 // Like FlatMap, but blocks until the input channel is closed and all values are read.
 // FlatMapValues reads all values from the input channel and returns a flattened array of
 // values returned from passing each input value into `mapFn`.
-func FlatMapValues[TIn any, TOut any, TOutSlice []TOut](inc <-chan TIn, mapFn func(TIn) TOutSlice) []TOut {
+func FlatMapValues[TIn any, TOut any, TOutSlice []TOut](inc <-chan TIn, mapFn func(TIn) (TOutSlice, bool)) []TOut {
 	outc := FlatMap(inc, mapFn)
 	result := make([]TOut, 0, len(inc))
 

--- a/flat_map_test.go
+++ b/flat_map_test.go
@@ -11,11 +11,14 @@ func TestFlatMap(t *testing.T) {
 	in := make(chan int, 100)
 	defer close(in)
 
-	out := channels.FlatMap(in, func(i int) []int { return []int{i * 10, i*10 + 1} })
+	out := channels.FlatMap(in, func(i int) ([]int, bool) {
+		return []int{i * 10, i*10 + 1}, i < 3
+	})
 	require.Equal(t, cap(in), cap(out))
 
 	in <- 1
 	in <- 2
+	in <- 3
 
 	require.Equal(t, <-out, 10)
 	require.Equal(t, <-out, 11)
@@ -29,9 +32,12 @@ func TestFlatMapValues(t *testing.T) {
 
 	in <- 1
 	in <- 2
+	in <- 3
 	close(in)
 
-	out := channels.FlatMapValues(in, func(i int) []int { return []int{i * 10, i*10 + 1} })
+	out := channels.FlatMapValues(in, func(i int) ([]int, bool) {
+		return []int{i * 10, i*10 + 1}, i < 3
+	})
 
 	require.Len(t, out, 4)
 	require.Equal(t, out, []int{10, 11, 20, 21})

--- a/map.go
+++ b/map.go
@@ -6,13 +6,17 @@ package channels
 // closed once the input channel is closed and all mapped values pushed to
 // the output channel.  The type of the output channel does not need to match
 // the type of the input channel.
-func Map[TIn any, TOut any](inc <-chan TIn, mapFn func(TIn) TOut) <-chan TOut {
+func Map[TIn any, TOut any](inc <-chan TIn, mapFn func(TIn) (TOut, bool)) <-chan TOut {
 	outc := make(chan TOut, cap(inc))
 
 	go func() {
 		defer close(outc)
 		for in := range inc {
-			outc <- mapFn(in)
+			val, ok := mapFn(in)
+			if !ok {
+				continue
+			}
+			outc <- val
 		}
 	}()
 
@@ -22,7 +26,7 @@ func Map[TIn any, TOut any](inc <-chan TIn, mapFn func(TIn) TOut) <-chan TOut {
 // Like Map, but blocks until the input channel is closed and all values are read.
 // MapsValues reads all values from the input channel and returns an array of
 // values returned from passing each input value into `mapFn`.
-func MapValues[TIn any, TOut any](inc <-chan TIn, mapFn func(TIn) TOut) []TOut {
+func MapValues[TIn any, TOut any](inc <-chan TIn, mapFn func(TIn) (TOut, bool)) []TOut {
 	outc := Map(inc, mapFn)
 	result := make([]TOut, 0, len(inc))
 

--- a/map_test.go
+++ b/map_test.go
@@ -2,7 +2,6 @@ package channels_test
 
 import (
 	"testing"
-	"time"
 
 	"github.com/jonabc/channels"
 	"github.com/stretchr/testify/require"
@@ -12,17 +11,18 @@ func TestMap(t *testing.T) {
 	in := make(chan int, 100)
 	defer close(in)
 
-	out := channels.Map(in, func(i int) bool { return i%2 == 0 })
+	out := channels.Map(in, func(i int) (bool, bool) {
+		return i%2 == 0, i < 3
+	})
 	require.Equal(t, cap(in), cap(out))
 
 	in <- 1
 	in <- 2
+	in <- 3
 
-	time.Sleep(1 * time.Millisecond)
-
-	require.Len(t, out, 2)
 	require.Equal(t, <-out, false)
 	require.Equal(t, <-out, true)
+	require.Len(t, out, 0)
 }
 
 func TestMapValues(t *testing.T) {
@@ -30,9 +30,12 @@ func TestMapValues(t *testing.T) {
 
 	in <- 1
 	in <- 2
+	in <- 3
 	close(in)
 
-	out := channels.MapValues(in, func(i int) bool { return i%2 == 0 })
+	out := channels.MapValues(in, func(i int) (bool, bool) {
+		return i%2 == 0, i < 3
+	})
 
 	require.Len(t, out, 2)
 	require.Equal(t, out, []bool{false, true})


### PR DESCRIPTION
allow caller-provided mutation functions to return false, signalling that the mutated value should not be propagated.

This is intended to be used for mutators that can result in errors.  This package is intended to be very lightweight, with graceful error handling performed inside the mutator function.  However if an error does occur the caller may not want to propagate the value.