### PR TITLE
Panic handling and output capacity options

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,9 @@ Some utilities for working with channels.
 
 While this library is useful for creating chained operations into a pipeline, it is intended to be lightweight. Pipeline orchestration, error handling, logging, and metrics tracking should be implemented by callers.
 
-## Batch
+## Functions
+
+### Batch
 
 ```go
 // signature
@@ -24,7 +26,7 @@ results := <- outc
 
 Batch N values from the input channel into an array of N values in the output channel.  The output channel will have capacity $`cap(input channel) / batchSize`$.  The output channel is closed once the input channel is closed and a partial batch is sent to the output channel, if a partial batch exists.
 
-## BatchValues (Blocking)
+### BatchValues (Blocking)
 
 ```go
 // signature
@@ -44,7 +46,7 @@ results := BatchValues(inc, 2)
 
 Like Batch, but blocks until the input channel is closed and all values are read.  BatchValue reads all values from the input channel and returns an array of batches.
 
-## Debounce
+### Debounce
 
 ```go
 // signature
@@ -79,7 +81,7 @@ Debounce also returns a function which returns the number of debounced values th
 
 For more complicated use cases, see [DebounceCustom](./#debouncecustom) below
 
-## DebounceCustom
+### DebounceCustom
 
 ```go
 // signature
@@ -155,7 +157,7 @@ The channel returned by DebounceCustom has the same capacity as the input channe
 
 DebounceCustom also returns a function which returns the number of debounced values that are currently being delayed.
 
-## FlatMap
+### FlatMap
 
 ```go
 // signature
@@ -182,7 +184,7 @@ FlatMap reads values from the input channel and applies the provided `mapFn` to 
 
 The output channel will have the same capacity as the input channel, and is closed once the input channel is closed and all mapped values are pushed to the output channel.
 
-## FlatMapValues (Blocking)
+### FlatMapValues (Blocking)
 
 ```go
 // signature
@@ -203,7 +205,7 @@ results := FlatMapValues(inc, func(i int) ([]int, bool) { return []int{i*10,i*10
 
 Like FlatMap, but blocks until the input channel is closed and all values are read.  FlatMapValues reads all values from the input channel and returns a flattened array of values returned from passing each input value into `mapFn`.
 
-## Map
+### Map
 
 ```go
 // signature
@@ -212,7 +214,7 @@ func Map[TIn any, TOut any](inc <-chan TIn, mapFn func(TIn) (TOut, bool)) <- cha
 // usage
 inc := make(chan int)
 // map integers to a boolean indicating if the values are odd (false) or even (true)
-outc := Map(inc, func(i int) (bool, bool) { return i%2 == 0, i < 3> })
+outc := Map(inc, func(i int) (bool, bool) { return i%2 == 0, i < 3 })
 
 inc <- 1
 inc <- 2
@@ -228,7 +230,7 @@ for result := range outc {
 
 Map reads values from the input channel and applies the provided `mapFn` to each value before pushing it to the output channel.  The output channel will have the same capacity as the input channel.  The output channel is closed once the input channel is closed and all mapped values pushed to the output channel.  The type of the output channel does not need to match the type of the input channel.
 
-## MapValues (Blocking)
+### MapValues (Blocking)
 
 ```go
 // signature
@@ -249,7 +251,7 @@ results := Map(inc, func(i int) (bool, bool) { return i%2 == 0, i < 3 })
 
 Like Map, but blocks until the input channel is closed and all values are read.  MapsValues reads all values from the input channel and returns an array of values returned from passing each input value into `mapFn`.
 
-## Merge
+### Merge
 
 ```go
 // signature
@@ -288,7 +290,7 @@ wg.Wait()
 
 Merge merges multiple input channels into a single output channel.  The order of values in the output channel is not guaranteed to match the order that values are written to the input channels.  The output channel has `capacity` capacity and is closed when all input channels are closed.
 
-## Reduce
+### Reduce
 
 ```go
 // signature
@@ -327,7 +329,7 @@ Reduce reads values from the input channel and applies the provided `reduceFn` t
 
 The output of each call to the reducer function is pushed to the output channel.
 
-## ReduceValues (Blocking)
+### ReduceValues (Blocking)
 
 ```go
 // signature
@@ -346,7 +348,7 @@ results := ReduceValues(inc, func(accum []string, i int) bool { return append(ac
 
 Like Reduce, but blocks until the input channel is closed and all values are read.  ReduceValues reads all values from the input channel and returns the value returned after all values from the input channel have been passed into `reduceFn`.
 
-## Reject
+### Reject
 
 ```go
 // signature
@@ -370,7 +372,7 @@ for result := range outc {
 
 Selects values from the input channel that return false from the provided `rejectFn` and pushes them to the output channel.  The output channel will have the same capacity as the input channel.  The output channel is closed once the input channel is closed and all selected values pushed to the output channel.
 
-## RejectValues (Blocking)
+### RejectValues (Blocking)
 
 ```go
 // signature
@@ -415,7 +417,7 @@ for result := range outc {
 Selects values from the input channel that return true from the provided `selectFn` and pushes them to the output channel.  The output channel will have the same capacity as the input channel.  The output channel is closed once the input channel is closed and all selected values pushed to the output channel.
 
 
-## SelectValues (Blocking)
+### SelectValues (Blocking)
 
 ```go
 // signature
@@ -435,7 +437,7 @@ result := SelectValues(inc, func(i int) bool { return i%2 == 0 })
 
 Like Select, but blocks until the input channel is closed and all values are read.  SelectValues reads all values from the input channel and returns an array values that return true from the provided `selectFn` function.
 
-## Split
+### Split
 
 ```go
 // signature
@@ -470,7 +472,7 @@ Split reads values from the input channel and routes the values into `N` output 
 
 Each output channel will have the same capacity as the input channel and will be closed after the input channel is closed and emptied.
 
-## SplitValues (Blocking)
+### SplitValues (Blocking)
 
 ```go
 // signature
@@ -496,7 +498,7 @@ Like Split, but blocks until the input channel is closed and all values are read
 - The first dimension, `i` in `[i][j]T` matches the size and order of channels provided to `splitFn`
 - The second dimension, `j` in `[i][j]T` matches the size and order of values written to `chans[i]` in `splitFn`
 
-## Tap
+### Tap
 
 ```go
 // signature
@@ -521,7 +523,7 @@ for result := range outc {
 
 Tap reads values from the input channel and calls the provided `[pre/post]Fn` functions with each value before and after writing the value to the output channel, respectivel.  The output channel has the same capacity as the input channel, and will be closed after the input channel is closed and drained.
 
-## WithDone
+### WithDone
 
 ```go
 // signature
@@ -552,3 +554,72 @@ close(inc)
 WithDone returns two channels: a channel containing piped input from the input channel as well and a channel which will be closed when the input channel has been closed and all values written to the piped output channel.
 
 WithDone is meant to be used in situations where a component needs awareness of the lifetime of a channel but interacting with the channel directly is not desirable.  In the example above, the `done` channel is used in a goroutine to report the current length of the channel at a regular interval.
+
+## Options
+
+###  Specifying output channel capacity (single channel output)
+
+Functions returning a single output channel set a capacity calculated from the input channel; see each function description for default output channel capacities.  The output channel capacity can be overridden by passing `channels.ChannelCapacityOption` to the function.
+
+```go
+// signature
+channels.ChannelCapacityOption[T singleOutputConfiguration](capacity int)
+
+// usage
+inc := make(chan int, 10)
+defer close(inc)
+
+// map integers to a boolean indicating if the values are odd (false) or even (true)
+outc := Map(inc, 
+  func(i int) (bool, bool) { return i%2 == 0, i < 3 },
+  channels.ChannelCapacityOption[channels.MapConfig](1),
+)
+
+// cap(outc) == 1
+```
+
+### Specifying output channels' capacities (multi channel output)
+
+Functions returning multiple output channels set capacities onto the channels calculated from the input channel; see each function description for default output channel capacities.  The output channel capacities can be overridden by passing `channels.ChannelCapacityOption` to the function.
+
+```go
+// signature
+channels.MultiChannelCapacitiesOption[T multiOutputConfiguration](capacities []int)
+
+// usage
+inc := make(chan int, 10)
+defer close(inc)
+
+outcs := Split(inc, 2,
+  func(i int, chans []chan<- int) { chans[i%2] <- i },
+  channels.MultiChannelCapacitiesOption[channels.SplitConfig]([]int{3,4}),
+)
+
+// cap(outcs[0]) == 3
+// cap(outcs[0]) == 4
+```
+
+### Specifying a channel for panic reporting
+
+Most of the behavior in this package happens in goroutines, and a panic can cause an application to crash without triggering any configured logging or graceful error handling behaviors.  Panics can be captured and proxied to callers by passing `channels.ErrorChannelOption` to the function.
+
+```go
+// signature
+channels.ErrorChannelOption[T errorConfiguration](chan<- any)
+
+// usage
+inc := make(chan int, 10)
+defer close(inc)
+
+errs := make(chan error)
+defer close(errs)
+
+// map integers to a boolean indicating if the values are odd (false) or even (true)
+outc := Map(inc, 
+  func(i int) (bool, bool) { panic("oops") },
+  channels.ErrorChannelOption[channels.MapConfig](errs),
+)
+
+inc <- 1
+// "oops" == <- errs 
+```

--- a/batch.go
+++ b/batch.go
@@ -6,13 +6,27 @@ import (
 	internalTime "github.com/jonabc/channels/internal/time"
 )
 
+// BatchConfig contains user configurable options for the Batch functions
+type BatchConfig struct {
+	panc     chan<- any
+	capacity int
+}
+
+func defaultBatchOptions[T any](inc <-chan T, batchSize int) []Option[BatchConfig] {
+	return []Option[BatchConfig]{
+		ChannelCapacityOption[BatchConfig](cap(inc) / batchSize),
+	}
+}
+
 // Batch N values from the input channel into an array of N values in the output channel.
 // The output channel will have capacity $`cap(input channel) / batchSize`$.
 // The output channel is closed once the input channel is closed and a partial batch is
 // sent to the output channel, if a partial batch exists.
-func Batch[T any](inc <-chan T, batchSize int, maxDelay time.Duration) <-chan []T {
-	channelCapacity := cap(inc) / batchSize
-	outc := make(chan []T, channelCapacity)
+func Batch[T any](inc <-chan T, batchSize int, maxDelay time.Duration, opts ...Option[BatchConfig]) <-chan []T {
+	cfg := parseOpts(append(defaultBatchOptions(inc, batchSize), opts...)...)
+
+	outc := make(chan []T, cfg.capacity)
+	panc := cfg.panc
 	buffer := make([]T, 0, batchSize)
 
 	timer := internalTime.NewTimer(maxDelay)
@@ -31,8 +45,10 @@ func Batch[T any](inc <-chan T, batchSize int, maxDelay time.Duration) <-chan []
 	}
 
 	go func() {
+		defer handlePanicIfErrc(panc)
 		defer close(outc)
 		defer timer.Stop()
+
 		for {
 			select {
 			case in, ok := <-inc:
@@ -60,8 +76,8 @@ func Batch[T any](inc <-chan T, batchSize int, maxDelay time.Duration) <-chan []
 
 // Like Batch, but blocks until the input channel is closed and all values are read.
 // BatchValue reads all values from the input channel and returns an array of batches.
-func BatchValues[T any](inc <-chan T, batchSize int, maxDelay time.Duration) [][]T {
-	outc := Batch(inc, batchSize, maxDelay)
+func BatchValues[T any](inc <-chan T, batchSize int, maxDelay time.Duration, opts ...Option[BatchConfig]) [][]T {
+	outc := Batch(inc, batchSize, maxDelay, opts...)
 	result := make([][]T, 0, len(inc))
 
 	for out := range outc {

--- a/batch_test.go
+++ b/batch_test.go
@@ -90,3 +90,18 @@ func TestDoesNotDrainEmptyBatchOnChannelClose(t *testing.T) {
 
 	require.Len(t, out, 0)
 }
+
+func TestAcceptsOptions(t *testing.T) {
+	t.Parallel()
+
+	in := make(chan int, 100)
+	panc := make(chan any)
+	outCapacity := 1
+
+	out := channels.Batch(in, 5, 0,
+		channels.ErrorChannelOption[channels.BatchConfig](panc),
+		channels.ChannelCapacityOption[channels.BatchConfig](outCapacity),
+	)
+
+	require.Equal(t, outCapacity, cap(out))
+}

--- a/errors.go
+++ b/errors.go
@@ -1,0 +1,13 @@
+package channels
+
+func handlePanicIfErrc(panc chan<- any) {
+	// don't handle the panic if a panic channel isn't provided
+	// is not provided
+	if panc == nil {
+		return
+	}
+
+	if err := recover(); err != nil {
+		panc <- err
+	}
+}

--- a/flat_map.go
+++ b/flat_map.go
@@ -1,16 +1,33 @@
 package channels
 
+// FlatMapConfig contains user configurable options for the FlatMap functions
+type FlatMapConfig struct {
+	panc     chan<- any
+	capacity int
+}
+
+func defaultFlatMapOptions[T any](inc <-chan T) []Option[FlatMapConfig] {
+	return []Option[FlatMapConfig]{
+		ChannelCapacityOption[FlatMapConfig](cap(inc)),
+	}
+}
+
 // FlatMap reads values from the input channel and applies the provided `mapFn`
 // to each value.  Each element in the slice returned by `mapFn` is then sent to the
 // output channel.
 // The output channel will have the same capacity as the input channel, and is
 // closed once the input channel is closed and all mapped values are pushed to
 // the output channel.
-func FlatMap[TIn any, TOut any, TOutSlice []TOut](inc <-chan TIn, mapFn func(TIn) (TOutSlice, bool)) <-chan TOut {
-	outc := make(chan TOut, cap(inc))
+func FlatMap[TIn any, TOut any, TOutSlice []TOut](inc <-chan TIn, mapFn func(TIn) (TOutSlice, bool), opts ...Option[FlatMapConfig]) <-chan TOut {
+	cfg := parseOpts(append(defaultFlatMapOptions(inc), opts...)...)
+
+	outc := make(chan TOut, cfg.capacity)
+	panc := cfg.panc
 
 	go func() {
+		defer handlePanicIfErrc(panc)
 		defer close(outc)
+
 		for in := range inc {
 			outSlice, ok := mapFn(in)
 			if !ok {
@@ -29,8 +46,8 @@ func FlatMap[TIn any, TOut any, TOutSlice []TOut](inc <-chan TIn, mapFn func(TIn
 // Like FlatMap, but blocks until the input channel is closed and all values are read.
 // FlatMapValues reads all values from the input channel and returns a flattened array of
 // values returned from passing each input value into `mapFn`.
-func FlatMapValues[TIn any, TOut any, TOutSlice []TOut](inc <-chan TIn, mapFn func(TIn) (TOutSlice, bool)) []TOut {
-	outc := FlatMap(inc, mapFn)
+func FlatMapValues[TIn any, TOut any, TOutSlice []TOut](inc <-chan TIn, mapFn func(TIn) (TOutSlice, bool), opts ...Option[FlatMapConfig]) []TOut {
+	outc := FlatMap(inc, mapFn, opts...)
 	result := make([]TOut, 0, len(inc))
 
 	for out := range outc {

--- a/map_test.go
+++ b/map_test.go
@@ -44,3 +44,24 @@ func TestMapValues(t *testing.T) {
 	require.Len(t, out, 2)
 	require.Equal(t, out, []bool{false, true})
 }
+
+func TestMapAcceptsOptions(t *testing.T) {
+	t.Parallel()
+
+	in := make(chan int, 100)
+	defer close(in)
+
+	errs := make(chan any)
+	defer close(errs)
+
+	out := channels.Map(in,
+		func(i int) (bool, bool) { panic("panic!") },
+		channels.ChannelCapacityOption[channels.MapConfig](5),
+		channels.ErrorChannelOption[channels.MapConfig](errs),
+	)
+
+	require.Equal(t, 5, cap(out))
+
+	in <- 1
+	require.Equal(t, "panic!", <-errs)
+}

--- a/merge_test.go
+++ b/merge_test.go
@@ -37,7 +37,7 @@ func TestMerge(t *testing.T) {
 				}(channel, i)
 			}
 
-			merged := channels.Merge(3, chans...)
+			merged := channels.Merge(3, chans)
 			if len(chans) == 1 {
 				require.Equal(t, chans[0], merged)
 			} else {

--- a/options.go
+++ b/options.go
@@ -1,0 +1,107 @@
+package channels
+
+type channelConfiguration interface {
+	BatchConfig |
+		DebounceConfig |
+		FlatMapConfig |
+		MapConfig |
+		MergeConfig |
+		ReduceConfig |
+		RejectConfig |
+		SelectConfig |
+		SplitConfig |
+		TapConfig
+}
+
+type Option[T channelConfiguration] func(*T)
+
+type errorConfiguration interface {
+	channelConfiguration
+}
+
+// Specify a channel which should receive the value returned by `recover` if
+// a panic happens, for reporting and/or graceful handling.
+func ErrorChannelOption[T errorConfiguration](panc chan<- any) Option[T] {
+	return func(cfg *T) {
+		switch cfg := any(cfg).(type) {
+		case *BatchConfig:
+			cfg.panc = panc
+		case *DebounceConfig:
+			cfg.panc = panc
+		case *FlatMapConfig:
+			cfg.panc = panc
+		case *MapConfig:
+			cfg.panc = panc
+		case *MergeConfig:
+			cfg.panc = panc
+		case *ReduceConfig:
+			cfg.panc = panc
+		case *RejectConfig:
+			cfg.panc = panc
+		case *SelectConfig:
+			cfg.panc = panc
+		case *SplitConfig:
+			cfg.panc = panc
+		case *TapConfig:
+			cfg.panc = panc
+		}
+	}
+}
+
+type singleOutputConfiguration interface {
+	BatchConfig |
+		DebounceConfig |
+		FlatMapConfig |
+		MapConfig |
+		ReduceConfig |
+		RejectConfig |
+		SelectConfig |
+		TapConfig
+}
+
+// Specify the capacity for a single output channel returned by a channels function.
+func ChannelCapacityOption[T singleOutputConfiguration](capacity int) func(*T) {
+	return func(cfg *T) {
+		switch cfg := any(cfg).(type) {
+		case *BatchConfig:
+			cfg.capacity = capacity
+		case *DebounceConfig:
+			cfg.capacity = capacity
+		case *FlatMapConfig:
+			cfg.capacity = capacity
+		case *MapConfig:
+			cfg.capacity = capacity
+		case *ReduceConfig:
+			cfg.capacity = capacity
+		case *RejectConfig:
+			cfg.capacity = capacity
+		case *SelectConfig:
+			cfg.capacity = capacity
+		case *TapConfig:
+			cfg.capacity = capacity
+		}
+	}
+}
+
+type multiOutputConfiguration interface {
+	SplitConfig
+}
+
+// Specify the capacities for output channels created from functions which return multiple channels.
+func MultiChannelCapacitiesOption[T multiOutputConfiguration](capacities []int) func(*T) {
+	return func(cfg *T) {
+		switch cfg := any(cfg).(type) {
+		case *SplitConfig:
+			cfg.capacities = capacities
+		}
+	}
+}
+
+func parseOpts[C any, O ~func(*C)](opts ...O) *C {
+	cfg := new(C)
+	for _, opt := range opts {
+		opt(cfg)
+	}
+
+	return cfg
+}

--- a/reduce.go
+++ b/reduce.go
@@ -1,16 +1,32 @@
 package channels
 
+type ReduceConfig struct {
+	capacity int
+	panc     chan<- any
+}
+
+func defaultReduceOptions[T any](inc <-chan T) []Option[ReduceConfig] {
+	return []Option[ReduceConfig]{
+		ChannelCapacityOption[ReduceConfig](cap(inc)),
+	}
+}
+
 // Reduce reads values from the input channel and applies the provided `reduceFn` to each value.
 // The first argument to the reducer function is the accumulated reduced value, which is either
 // 1. the default value for the type on the first call
 // 2. the output from the previous call of the reducer function for all other iterations.
 
 // The output of each call to the reducer function is pushed to the output channel.
-func Reduce[TIn any, TOut any](inc <-chan TIn, reduceFn func(TOut, TIn) (TOut, bool)) <-chan TOut {
-	outc := make(chan TOut, cap(inc))
+func Reduce[TIn any, TOut any](inc <-chan TIn, reduceFn func(TOut, TIn) (TOut, bool), opts ...Option[ReduceConfig]) <-chan TOut {
+	cfg := parseOpts(append(defaultReduceOptions(inc), opts...)...)
+
+	outc := make(chan TOut, cfg.capacity)
+	panc := cfg.panc
 
 	go func() {
+		defer handlePanicIfErrc(panc)
 		defer close(outc)
+
 		var result TOut
 		for in := range inc {
 			next, ok := reduceFn(result, in)
@@ -28,8 +44,8 @@ func Reduce[TIn any, TOut any](inc <-chan TIn, reduceFn func(TOut, TIn) (TOut, b
 // Like Reduce, but blocks until the input channel is closed and all values are read.
 // ReduceValues reads all values from the input channel and returns the value returned
 // after all values from the input channel have been passed into `reduceFn`.
-func ReduceValues[TIn any, TOut any](inc <-chan TIn, reduceFn func(TOut, TIn) (TOut, bool)) TOut {
-	outc := Reduce(inc, reduceFn)
+func ReduceValues[TIn any, TOut any](inc <-chan TIn, reduceFn func(TOut, TIn) (TOut, bool), opts ...Option[ReduceConfig]) TOut {
+	outc := Reduce(inc, reduceFn, opts...)
 	var result TOut
 	for out := range outc {
 		result = out

--- a/reduce_test.go
+++ b/reduce_test.go
@@ -51,3 +51,24 @@ func TestReduceValues(t *testing.T) {
 	})
 	require.Equal(t, out, 7)
 }
+
+func TestReduceAcceptsOptions(t *testing.T) {
+	t.Parallel()
+
+	in := make(chan int, 100)
+	defer close(in)
+
+	errs := make(chan any)
+	defer close(errs)
+
+	out := channels.Reduce(in,
+		func(i int, j int) (int, bool) { panic("panic!") },
+		channels.ChannelCapacityOption[channels.ReduceConfig](5),
+		channels.ErrorChannelOption[channels.ReduceConfig](errs),
+	)
+
+	require.Equal(t, 5, cap(out))
+
+	in <- 1
+	require.Equal(t, "panic!", <-errs)
+}

--- a/reject.go
+++ b/reject.go
@@ -1,0 +1,49 @@
+package channels
+
+type RejectConfig struct {
+	panc     chan<- any
+	capacity int
+}
+
+func defaultRejectOptions[T any](inc <-chan T) []Option[RejectConfig] {
+	return []Option[RejectConfig]{
+		ChannelCapacityOption[RejectConfig](cap(inc)),
+	}
+}
+
+// Selects values from the input channel that return false from the provided `rejectFn`
+// and pushes them to the output channel.  The output channel will have the same capacity
+// as the input channel.  The output channel is closed once the input channel is closed
+// and all selected values pushed to the output channel.
+func Reject[T any](inc <-chan T, rejectFn func(T) bool, opts ...Option[RejectConfig]) <-chan T {
+	cfg := parseOpts(append(defaultRejectOptions(inc), opts...)...)
+
+	outc := make(chan T, cfg.capacity)
+	panc := cfg.panc
+
+	go func() {
+		defer handlePanicIfErrc(panc)
+		defer close(outc)
+
+		for in := range inc {
+			if !rejectFn(in) {
+				outc <- in
+			}
+		}
+	}()
+
+	return outc
+}
+
+// Like Reject, but blocks until the input channel is closed and all values are read.
+// RejectValues reads all values from the input channel and returns an array of values
+// that return false from the provided `rejectFn` function.
+func RejectValues[T any](inc <-chan T, rejectFn func(T) bool, opts ...Option[RejectConfig]) []T {
+	outc := Reject(inc, rejectFn, opts...)
+	result := make([]T, 0, len(inc))
+	for out := range outc {
+		result = append(result, out)
+	}
+
+	return result
+}

--- a/reject_test.go
+++ b/reject_test.go
@@ -9,13 +9,13 @@ import (
 	"github.com/jonabc/channels"
 )
 
-func TestSelect(t *testing.T) {
+func TestReject(t *testing.T) {
 	t.Parallel()
 
 	in := make(chan int, 100)
 	defer close(in)
 
-	out := channels.Select(in, func(i int) bool { return i%2 == 0 })
+	out := channels.Reject(in, func(i int) bool { return i%2 == 0 })
 	require.Equal(t, cap(in), cap(out))
 
 	in <- 1
@@ -24,10 +24,10 @@ func TestSelect(t *testing.T) {
 	time.Sleep(1 * time.Millisecond)
 
 	require.Len(t, out, 1)
-	require.Equal(t, <-out, 2)
+	require.Equal(t, <-out, 1)
 }
 
-func TestSelectValues(t *testing.T) {
+func TestRejectValues(t *testing.T) {
 	t.Parallel()
 
 	in := make(chan int, 100)
@@ -36,13 +36,13 @@ func TestSelectValues(t *testing.T) {
 	in <- 2
 	close(in)
 
-	out := channels.SelectValues(in, func(i int) bool { return i%2 == 0 })
+	out := channels.RejectValues(in, func(i int) bool { return i%2 == 0 })
 
 	require.Len(t, out, 1)
-	require.Equal(t, out, []int{2})
+	require.Equal(t, out, []int{1})
 }
 
-func TestSelectAcceptsOptions(t *testing.T) {
+func TestRejectAcceptsOptions(t *testing.T) {
 	t.Parallel()
 
 	in := make(chan int, 100)
@@ -51,10 +51,10 @@ func TestSelectAcceptsOptions(t *testing.T) {
 	errs := make(chan any)
 	defer close(errs)
 
-	out := channels.Select(in,
+	out := channels.Reject(in,
 		func(i int) bool { panic("panic!") },
-		channels.ChannelCapacityOption[channels.SelectConfig](5),
-		channels.ErrorChannelOption[channels.SelectConfig](errs),
+		channels.ChannelCapacityOption[channels.RejectConfig](5),
+		channels.ErrorChannelOption[channels.RejectConfig](errs),
 	)
 
 	require.Equal(t, 5, cap(out))

--- a/select.go
+++ b/select.go
@@ -1,14 +1,30 @@
 package channels
 
+type SelectConfig struct {
+	panc     chan<- any
+	capacity int
+}
+
+func defaultSelectOptions[T any](inc <-chan T) []Option[SelectConfig] {
+	return []Option[SelectConfig]{
+		ChannelCapacityOption[SelectConfig](cap(inc)),
+	}
+}
+
 // Selects values from the input channel that return true from the provided `selectFn`
 // and pushes them to the output channel.  The output channel will have the same capacity
 // as the input channel.  The output channel is closed once the input channel is closed
 // and all selected values pushed to the output channel.
-func Select[T any](inc <-chan T, selectFn func(T) bool) <-chan T {
-	outc := make(chan T, cap(inc))
+func Select[T any](inc <-chan T, selectFn func(T) bool, opts ...Option[SelectConfig]) <-chan T {
+	cfg := parseOpts(append(defaultSelectOptions(inc), opts...)...)
+
+	outc := make(chan T, cfg.capacity)
+	panc := cfg.panc
 
 	go func() {
+		defer handlePanicIfErrc(panc)
 		defer close(outc)
+
 		for in := range inc {
 			if selectFn(in) {
 				outc <- in
@@ -22,27 +38,12 @@ func Select[T any](inc <-chan T, selectFn func(T) bool) <-chan T {
 // Like Select, but blocks until the input channel is closed and all values are read.
 // SelectValues reads all values from the input channel and returns an array values
 // that return true from the provided `selectFn` function.
-func SelectValues[T any](inc <-chan T, selectFn func(T) bool) []T {
-	outc := Select(inc, selectFn)
+func SelectValues[T any](inc <-chan T, selectFn func(T) bool, opts ...Option[SelectConfig]) []T {
+	outc := Select(inc, selectFn, opts...)
 	result := make([]T, 0, len(inc))
 	for out := range outc {
 		result = append(result, out)
 	}
 
 	return result
-}
-
-// Selects values from the input channel that return false from the provided `rejectFn`
-// and pushes them to the output channel.  The output channel will have the same capacity
-// as the input channel.  The output channel is closed once the input channel is closed
-// and all selected values pushed to the output channel.
-func Reject[T any](inc <-chan T, rejectFn func(T) bool) <-chan T {
-	return Select(inc, func(t T) bool { return !rejectFn(t) })
-}
-
-// Like Reject, but blocks until the input channel is closed and all values are read.
-// RejectValues reads all values from the input channel and returns an array of values
-// that return false from the provided `rejectFn` function.
-func RejectValues[T any](inc <-chan T, rejectFn func(T) bool) []T {
-	return SelectValues(inc, func(t T) bool { return !rejectFn(t) })
 }

--- a/tap.go
+++ b/tap.go
@@ -1,15 +1,31 @@
 package channels
 
+type TapConfig struct {
+	panc     chan<- any
+	capacity int
+}
+
+func defaultTapOptions[T any](inc <-chan T) []Option[TapConfig] {
+	return []Option[TapConfig]{
+		ChannelCapacityOption[TapConfig](cap(inc)),
+	}
+}
+
 // Tap reads values from the input channel and calls the provided
 // `[pre/post]Fn` functions with each value before and after writing
 // the value to the output channel, respectivel.  The output channel
 // has the same capacity as the input channel, and will be closed
 // after the input channel is closed and drained.
-func Tap[T any](inc <-chan T, preFn func(T), postFn func(T)) <-chan T {
-	outc := make(chan T, cap(inc))
+func Tap[T any](inc <-chan T, preFn func(T), postFn func(T), opts ...Option[TapConfig]) <-chan T {
+	cfg := parseOpts(append(defaultTapOptions(inc), opts...)...)
+
+	outc := make(chan T, cfg.capacity)
+	panc := cfg.panc
 
 	go func() {
+		defer handlePanicIfErrc(panc)
 		defer close(outc)
+
 		for val := range inc {
 			if preFn != nil {
 				preFn(val)

--- a/tap_test.go
+++ b/tap_test.go
@@ -34,3 +34,25 @@ func TestTap(t *testing.T) {
 	require.Equal(t, []int{1, 2}, post)
 	require.Len(t, out, 0)
 }
+
+func TestTapAcceptsOptions(t *testing.T) {
+	t.Parallel()
+
+	in := make(chan int, 10)
+	defer close(in)
+
+	errs := make(chan any)
+	defer close(errs)
+
+	out := channels.Tap(in,
+		func(i int) { panic("panic!") },
+		nil,
+		channels.ErrorChannelOption[channels.TapConfig](errs),
+		channels.ChannelCapacityOption[channels.TapConfig](1),
+	)
+
+	require.Equal(t, 1, cap(out))
+
+	in <- 1
+	require.Equal(t, "panic!", <-errs)
+}


### PR DESCRIPTION
Adds options for:
1. Setting custom output channel sizes
2. Caller-provided channels which receives any panics occurring in the function.