### PR TITLE
optimize output channel memory usage

### DIFF
--- a/batch.go
+++ b/batch.go
@@ -14,18 +14,12 @@ type BatchConfig struct {
 	capacity      int
 }
 
-func defaultBatchOptions[T any](inc <-chan T, batchSize int) []Option[BatchConfig] {
-	return []Option[BatchConfig]{
-		ChannelCapacityOption[BatchConfig](cap(inc) / batchSize),
-	}
-}
-
 // Batch N values from the input channel into an array of N values in the output channel.
 // The output channel will have capacity $`cap(input channel) / batchSize`$.
 // The output channel is closed once the input channel is closed and a partial batch is
 // sent to the output channel, if a partial batch exists.
 func Batch[T any](inc <-chan T, batchSize int, maxDelay time.Duration, opts ...Option[BatchConfig]) <-chan []T {
-	cfg := parseOpts(append(defaultBatchOptions(inc, batchSize), opts...)...)
+	cfg := parseOpts(opts...)
 
 	outc := make(chan []T, cfg.capacity)
 	panicProvider := cfg.panicProvider

--- a/batch_test.go
+++ b/batch_test.go
@@ -18,8 +18,7 @@ func TestBatchAfterMaxBatchSize(t *testing.T) {
 	batchSize := 5
 	out := channels.Batch(in, batchSize, 0)
 
-	maxBatches := cap(in) / batchSize
-	require.Equal(t, maxBatches, cap(out))
+	require.Equal(t, 0, cap(out))
 
 	go func() {
 		defer close(in)
@@ -55,9 +54,7 @@ func TestBatchAfterMaxDelay(t *testing.T) {
 	out := channels.Batch(in, batchSize, maxDelay)
 
 	in <- 1
-	time.Sleep(2 * maxDelay)
 
-	require.Len(t, out, 1)
 	require.Equal(t, <-out, []int{1})
 }
 
@@ -72,9 +69,7 @@ func TestBatchDrainsItemsOnInputChannelClose(t *testing.T) {
 	in <- 1
 
 	close(in)
-	time.Sleep(1 * time.Millisecond)
 
-	require.Len(t, out, 1)
 	require.Equal(t, <-out, []int{1})
 }
 

--- a/debounce.go
+++ b/debounce.go
@@ -14,12 +14,6 @@ type DebounceConfig struct {
 	capacity      int
 }
 
-func defaultDebounceOptions[T any](inc <-chan T) []Option[DebounceConfig] {
-	return []Option[DebounceConfig]{
-		ChannelCapacityOption[DebounceConfig](cap(inc)),
-	}
-}
-
 type Keyable[K comparable] interface {
 	Key() K
 }
@@ -60,7 +54,7 @@ func (i *debounceInputComparable[T]) Reduce(*debounceInputComparable[T]) (*debou
 // Debounce also returns a function which returns the number of debounced values
 // that are currently being delayed
 func Debounce[T comparable](inc <-chan T, delay time.Duration, opts ...Option[DebounceConfig]) (<-chan T, func() int) {
-	cfg := parseOpts(append(defaultDebounceOptions(inc), opts...)...)
+	cfg := parseOpts(opts...)
 
 	outc := make(chan T, cfg.capacity)
 
@@ -99,7 +93,7 @@ func Debounce[T comparable](inc <-chan T, delay time.Duration, opts ...Option[De
 // DebounceCustom also returns a function which returns the number of debounced values
 // that are currently being delayed
 func DebounceCustom[K comparable, T DebounceInput[K, T]](inc <-chan T, opts ...Option[DebounceConfig]) (<-chan T, func() int) {
-	cfg := parseOpts(append(defaultDebounceOptions(inc), opts...)...)
+	cfg := parseOpts(opts...)
 
 	outc := make(chan T, cfg.capacity)
 	done := make(chan struct{})

--- a/debounce_test.go
+++ b/debounce_test.go
@@ -17,7 +17,7 @@ func TestDebounce(t *testing.T) {
 
 	delay := 20 * time.Millisecond
 	outc, getDebouncedCount := channels.Debounce(inc, delay)
-	require.Equal(t, cap(inc), cap(outc))
+	require.Equal(t, 0, cap(outc))
 
 	start := time.Now()
 
@@ -88,7 +88,7 @@ func TestDebounceCustom(t *testing.T) {
 
 	delay := 5 * time.Millisecond
 	outc, getDebouncedCount := channels.DebounceCustom(inc)
-	require.Equal(t, cap(inc), cap(outc))
+	require.Equal(t, 0, cap(outc))
 
 	start := time.Now()
 

--- a/flat_map.go
+++ b/flat_map.go
@@ -13,12 +13,6 @@ type FlatMapConfig struct {
 	capacity      int
 }
 
-func defaultFlatMapOptions[T any](inc <-chan T) []Option[FlatMapConfig] {
-	return []Option[FlatMapConfig]{
-		ChannelCapacityOption[FlatMapConfig](cap(inc)),
-	}
-}
-
 // FlatMap reads values from the input channel and applies the provided `mapFn`
 // to each value.  Each element in the slice returned by `mapFn` is then sent to the
 // output channel.
@@ -26,7 +20,7 @@ func defaultFlatMapOptions[T any](inc <-chan T) []Option[FlatMapConfig] {
 // closed once the input channel is closed and all mapped values are pushed to
 // the output channel.
 func FlatMap[TIn any, TOut any, TOutSlice []TOut](inc <-chan TIn, mapFn func(TIn) (TOutSlice, bool), opts ...Option[FlatMapConfig]) <-chan TOut {
-	cfg := parseOpts(append(defaultFlatMapOptions(inc), opts...)...)
+	cfg := parseOpts(opts...)
 
 	outc := make(chan TOut, cfg.capacity)
 	panicProvider := cfg.panicProvider

--- a/flat_map_test.go
+++ b/flat_map_test.go
@@ -13,22 +13,24 @@ func TestFlatMap(t *testing.T) {
 	t.Parallel()
 
 	in := make(chan int, 100)
-	defer close(in)
 
 	out := channels.FlatMap(in, func(i int) ([]int, bool) {
 		return []int{i * 10, i*10 + 1}, i < 3
 	})
-	require.Equal(t, cap(in), cap(out))
+	require.Equal(t, 0, cap(out))
 
 	in <- 1
 	in <- 2
 	in <- 3
+	close(in)
 
 	require.Equal(t, <-out, 10)
 	require.Equal(t, <-out, 11)
 	require.Equal(t, <-out, 20)
 	require.Equal(t, <-out, 21)
-	require.Len(t, out, 0)
+
+	_, ok := <-out
+	require.False(t, ok)
 }
 
 func TestFlatMapValues(t *testing.T) {

--- a/map.go
+++ b/map.go
@@ -12,12 +12,6 @@ type MapConfig struct {
 	capacity      int
 }
 
-func defaultMapOptions[T any](inc <-chan T) []Option[MapConfig] {
-	return []Option[MapConfig]{
-		ChannelCapacityOption[MapConfig](cap(inc)),
-	}
-}
-
 // Map reads values from the input channel and applies the provided `mapFn`
 // to each value before pushing it to the output channel.  The output channel
 // will have the same capacity as the input channel.  The output channel is
@@ -25,7 +19,7 @@ func defaultMapOptions[T any](inc <-chan T) []Option[MapConfig] {
 // the output channel.  The type of the output channel does not need to match
 // the type of the input channel.
 func Map[TIn any, TOut any](inc <-chan TIn, mapFn func(TIn) (TOut, bool), opts ...Option[MapConfig]) <-chan TOut {
-	cfg := parseOpts(append(defaultMapOptions(inc), opts...)...)
+	cfg := parseOpts(opts...)
 
 	outc := make(chan TOut, cfg.capacity)
 	panicProvider := cfg.panicProvider

--- a/map_test.go
+++ b/map_test.go
@@ -13,20 +13,22 @@ func TestMap(t *testing.T) {
 	t.Parallel()
 
 	in := make(chan int, 100)
-	defer close(in)
 
 	out := channels.Map(in, func(i int) (bool, bool) {
 		return i%2 == 0, i < 3
 	})
-	require.Equal(t, cap(in), cap(out))
+	require.Equal(t, 0, cap(out))
 
 	in <- 1
 	in <- 2
 	in <- 3
+	close(in)
 
 	require.Equal(t, <-out, false)
 	require.Equal(t, <-out, true)
-	require.Len(t, out, 0)
+
+	_, ok := <-out
+	require.False(t, ok)
 }
 
 func TestMapValues(t *testing.T) {

--- a/reduce.go
+++ b/reduce.go
@@ -12,12 +12,6 @@ type ReduceConfig struct {
 	capacity      int
 }
 
-func defaultReduceOptions[T any](inc <-chan T) []Option[ReduceConfig] {
-	return []Option[ReduceConfig]{
-		ChannelCapacityOption[ReduceConfig](cap(inc)),
-	}
-}
-
 // Reduce reads values from the input channel and applies the provided `reduceFn` to each value.
 // The first argument to the reducer function is the accumulated reduced value, which is either
 // 1. the default value for the type on the first call
@@ -25,7 +19,7 @@ func defaultReduceOptions[T any](inc <-chan T) []Option[ReduceConfig] {
 
 // The output of each call to the reducer function is pushed to the output channel.
 func Reduce[TIn any, TOut any](inc <-chan TIn, reduceFn func(TOut, TIn) (TOut, bool), opts ...Option[ReduceConfig]) <-chan TOut {
-	cfg := parseOpts(append(defaultReduceOptions(inc), opts...)...)
+	cfg := parseOpts(opts...)
 
 	outc := make(chan TOut, cfg.capacity)
 	panicProvider := cfg.panicProvider

--- a/reduce_test.go
+++ b/reduce_test.go
@@ -13,7 +13,6 @@ func TestReduce(t *testing.T) {
 	t.Parallel()
 
 	in := make(chan int, 100)
-	defer close(in)
 
 	out := channels.Reduce(in, func(current int, i int) (int, bool) {
 		if i == 3 {
@@ -21,17 +20,20 @@ func TestReduce(t *testing.T) {
 		}
 		return current + i, true
 	})
-	require.Equal(t, cap(in), cap(out))
+	require.Equal(t, 0, cap(out))
+
 	in <- 1
 	in <- 2
 	in <- 3
 	in <- 4
+	close(in)
 
 	require.Equal(t, 1, <-out)
 	require.Equal(t, 3, <-out)
 	require.Equal(t, 7, <-out)
 
-	require.Equal(t, 0, len(out))
+	_, ok := <-out
+	require.False(t, ok)
 }
 
 func TestReduceValues(t *testing.T) {

--- a/reject.go
+++ b/reject.go
@@ -12,18 +12,12 @@ type RejectConfig struct {
 	capacity      int
 }
 
-func defaultRejectOptions[T any](inc <-chan T) []Option[RejectConfig] {
-	return []Option[RejectConfig]{
-		ChannelCapacityOption[RejectConfig](cap(inc)),
-	}
-}
-
 // Selects values from the input channel that return false from the provided `rejectFn`
 // and pushes them to the output channel.  The output channel will have the same capacity
 // as the input channel.  The output channel is closed once the input channel is closed
 // and all selected values pushed to the output channel.
 func Reject[T any](inc <-chan T, rejectFn func(T) bool, opts ...Option[RejectConfig]) <-chan T {
-	cfg := parseOpts(append(defaultRejectOptions(inc), opts...)...)
+	cfg := parseOpts(opts...)
 
 	outc := make(chan T, cfg.capacity)
 	panicProvider := cfg.panicProvider

--- a/reject_test.go
+++ b/reject_test.go
@@ -14,18 +14,17 @@ func TestReject(t *testing.T) {
 	t.Parallel()
 
 	in := make(chan int, 100)
-	defer close(in)
 
 	out := channels.Reject(in, func(i int) bool { return i%2 == 0 })
-	require.Equal(t, cap(in), cap(out))
+	require.Equal(t, 0, cap(out))
 
-	in <- 1
 	in <- 2
+	in <- 1
+	close(in)
 
-	time.Sleep(1 * time.Millisecond)
-
-	require.Len(t, out, 1)
 	require.Equal(t, <-out, 1)
+	_, ok := <-out
+	require.False(t, ok)
 }
 
 func TestRejectValues(t *testing.T) {

--- a/select.go
+++ b/select.go
@@ -12,18 +12,12 @@ type SelectConfig struct {
 	capacity      int
 }
 
-func defaultSelectOptions[T any](inc <-chan T) []Option[SelectConfig] {
-	return []Option[SelectConfig]{
-		ChannelCapacityOption[SelectConfig](cap(inc)),
-	}
-}
-
 // Selects values from the input channel that return true from the provided `selectFn`
 // and pushes them to the output channel.  The output channel will have the same capacity
 // as the input channel.  The output channel is closed once the input channel is closed
 // and all selected values pushed to the output channel.
 func Select[T any](inc <-chan T, selectFn func(T) bool, opts ...Option[SelectConfig]) <-chan T {
-	cfg := parseOpts(append(defaultSelectOptions(inc), opts...)...)
+	cfg := parseOpts(opts...)
 
 	outc := make(chan T, cfg.capacity)
 	panicProvider := cfg.panicProvider

--- a/select_test.go
+++ b/select_test.go
@@ -14,18 +14,17 @@ func TestSelect(t *testing.T) {
 	t.Parallel()
 
 	in := make(chan int, 100)
-	defer close(in)
 
 	out := channels.Select(in, func(i int) bool { return i%2 == 0 })
-	require.Equal(t, cap(in), cap(out))
+	require.Equal(t, 0, cap(out))
 
 	in <- 1
 	in <- 2
+	close(in)
 
-	time.Sleep(1 * time.Millisecond)
-
-	require.Len(t, out, 1)
 	require.Equal(t, <-out, 2)
+	_, ok := <-out
+	require.False(t, ok)
 }
 
 func TestSelectValues(t *testing.T) {

--- a/split.go
+++ b/split.go
@@ -13,10 +13,10 @@ type SplitConfig struct {
 	capacities    []int
 }
 
-func defaultSplitOptions[T any](inc <-chan T, count int) []Option[SplitConfig] {
+func defaultSplitOptions(count int) []Option[SplitConfig] {
 	capacities := make([]int, count)
 	for i := 0; i < count; i++ {
-		capacities[i] = cap(inc)
+		capacities[i] = 1
 	}
 	return []Option[SplitConfig]{
 		MultiChannelCapacitiesOption[SplitConfig](capacities),
@@ -32,7 +32,7 @@ func defaultSplitOptions[T any](inc <-chan T, count int) []Option[SplitConfig] {
 // Each output channel will have the same capacity as the input channel and
 // will be closed after the input channel is closed and emptied.
 func Split[T any](inc <-chan T, count int, splitFn func(T, []chan<- T), opts ...Option[SplitConfig]) []<-chan T {
-	cfg := parseOpts(append(defaultSplitOptions(inc, count), opts...)...)
+	cfg := parseOpts(append(defaultSplitOptions(count), opts...)...)
 
 	writeOutc := make([]chan<- T, count)
 	readOutc := make([]<-chan T, count)

--- a/tap.go
+++ b/tap.go
@@ -12,19 +12,13 @@ type TapConfig struct {
 	capacity      int
 }
 
-func defaultTapOptions[T any](inc <-chan T) []Option[TapConfig] {
-	return []Option[TapConfig]{
-		ChannelCapacityOption[TapConfig](cap(inc)),
-	}
-}
-
 // Tap reads values from the input channel and calls the provided
 // `[pre/post]Fn` functions with each value before and after writing
 // the value to the output channel, respectivel.  The output channel
 // has the same capacity as the input channel, and will be closed
 // after the input channel is closed and drained.
 func Tap[T any](inc <-chan T, preFn func(T), postFn func(T), opts ...Option[TapConfig]) <-chan T {
-	cfg := parseOpts(append(defaultTapOptions(inc), opts...)...)
+	cfg := parseOpts(opts...)
 
 	outc := make(chan T, cfg.capacity)
 	panicProvider := cfg.panicProvider

--- a/tap_test.go
+++ b/tap_test.go
@@ -21,7 +21,7 @@ func TestTap(t *testing.T) {
 		func(i int) { post = append(post, i) },
 	)
 
-	require.Equal(t, cap(in), cap(out))
+	require.Equal(t, 0, cap(out))
 
 	in <- 1
 	in <- 2
@@ -34,7 +34,9 @@ func TestTap(t *testing.T) {
 	require.Equal(t, []int{1, 2}, results)
 	require.Equal(t, []int{1, 2}, pre)
 	require.Equal(t, []int{1, 2}, post)
-	require.Len(t, out, 0)
+
+	_, ok := <-out
+	require.False(t, ok)
 }
 
 func TestTapAcceptsOptions(t *testing.T) {


### PR DESCRIPTION
changes most functions to provide an unbuffered output channel, with split moving to a buffer length of 1.  this is intended to optimize memory usage and reduce any unexpected buffering.  In effect the functions become extensions of the final channel consumer rather an extension of the channel.