### PR TITLE
Return unbuffered channel by default from merge

### DIFF
--- a/README.md
+++ b/README.md
@@ -318,7 +318,7 @@ wg.Wait()
 // results will have the same elements as []int{1,2,3,4} but may not be in that order
 ```
 
-Merge merges multiple input channels into a single output channel.  The order of values in the output channel is not guaranteed to match the order that values are written to the input channels.  The output channel has `capacity` capacity and is closed when all input channels are closed.
+Merge merges multiple input channels into a single output channel.  The order of values in the output channel is not guaranteed to match the order that values are written to the input channels.  The output channel is unbuffered by default and is closed when all input channels are closed.
 
 ### Reduce
 

--- a/merge.go
+++ b/merge.go
@@ -8,14 +8,14 @@ import (
 
 type MergeConfig struct {
 	panicProvider providers.Provider[any]
+	capacity      int
 }
 
 // Merge merges multiple input channels into a single output channel.  The
 // order of values in the output channel is not guaranteed to match the
 // order that values are written to the input channels.  The output channel
-// has the same capacity as the input channel and is closed when all input
-// channels are closed.
-func Merge[T any](capacity int, chans []<-chan T, opts ...Option[MergeConfig]) <-chan T {
+// is unbuffered by default and is closed when all input channels are closed.
+func Merge[T any](chans []<-chan T, opts ...Option[MergeConfig]) <-chan T {
 	cfg := parseOpts(opts...)
 	panicProvider := cfg.panicProvider
 
@@ -26,7 +26,7 @@ func Merge[T any](capacity int, chans []<-chan T, opts ...Option[MergeConfig]) <
 		return chans[0]
 	default:
 		var wg sync.WaitGroup
-		outc := make(chan T, capacity)
+		outc := make(chan T, cfg.capacity)
 		i := 0
 
 		for len(chans)-i >= 4 {

--- a/options.go
+++ b/options.go
@@ -51,6 +51,7 @@ type singleOutputConfiguration interface {
 		DebounceConfig |
 		FlatMapConfig |
 		MapConfig |
+		MergeConfig |
 		ReduceConfig |
 		RejectConfig |
 		SelectConfig |
@@ -68,6 +69,8 @@ func ChannelCapacityOption[T singleOutputConfiguration](capacity int) Option[T] 
 		case *FlatMapConfig:
 			cfg.capacity = capacity
 		case *MapConfig:
+			cfg.capacity = capacity
+		case *MergeConfig:
 			cfg.capacity = capacity
 		case *ReduceConfig:
 			cfg.capacity = capacity

--- a/signal_test.go
+++ b/signal_test.go
@@ -13,7 +13,7 @@ func TestWithDone(t *testing.T) {
 	inc := make(chan int, 4)
 
 	outc, done := channels.WithDone(inc)
-	require.Equal(t, cap(inc), cap(outc))
+	require.Equal(t, 0, cap(outc))
 	require.Equal(t, 0, cap(done))
 	require.Empty(t, outc)
 


### PR DESCRIPTION
missed this when changing other output channel capacities recently