### PR TITLE
(Breaking) Debounce updates - debounce types, throttle helpers, value-agnostic debounce function

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,13 +84,20 @@ results += <- outc
 // results == 3, len(outc) == 0
 ```
 
-Debounce reads values from the input channel and pushes them to the returned output channel after a delay.  If a value is read from the input channel multiple times during the debounce period it will only be pushed to the output channel once, after a `delay` started from when the first of the value multiple values is read.
+Debounce reads values from the input channel and pushes them to the returned output channel before, after, or before and after a `delay` debounce period. The [DebounceType](#debounce-types) value used in the function controls when the value is pushed to the output channel.  Any duplicate values read from the input channel during the `delay` debounce period are ignored.
 
 The channel returned by Debounce is unbuffered by default.  When the input channel is closed, any remaining values being delayed/debounced will be flushed to the output channel and the output channel will be closed.
 
 Debounce also returns a function which returns the number of debounced values that are currently being delayed
 
-For more complicated use cases, see [DebounceCustom](./#debouncecustom) below
+For more complicated use cases, see [DebounceCustom](./#debouncecustom) below.
+
+#### Debounce Types
+
+When debouncing values, the value can either be written to the output channel before the debounce period starts (`LeadDebounceType`), after the debounce period ends (`TailDebounceType`) or both (`LeadTailDebounceType`).  The default is `TailDebounceType`.
+
+The debounce type can be set using the `DebounceTypeOption` function option.
+
 
 ### DebounceCustom
 

--- a/debounce.go
+++ b/debounce.go
@@ -1,66 +1,32 @@
 package channels
 
 import (
-	"sync"
 	"time"
-
-	"github.com/jonabc/channels/providers"
 )
 
-type DebounceType byte
-
-const (
-	TailDebounceType DebounceType = 1 << iota
-	LeadDebounceType
-	LeadTailDebounceType = TailDebounceType | LeadDebounceType
-)
-
-// DebounceConfig contains user configurable options for the Debounce functions
-type DebounceConfig struct {
-	panicProvider providers.Provider[any]
-	statsProvider providers.Provider[DebounceStats]
-	capacity      int
-	debounceType  DebounceType
-}
-
-func defaultDebounceOptions() []Option[DebounceConfig] {
-	return []Option[DebounceConfig]{
-		DebounceTypeOption(TailDebounceType),
-	}
-}
-
-type Keyable[K comparable] interface {
-	Key() K
-}
-
-type DebounceInput[K comparable, T Keyable[K]] interface {
-	Keyable[K]
-	Delay() time.Duration
-	Reduce(T) (T, bool)
-}
-
-type debounceInputComparable[T comparable] struct {
+type debounceInput[T any] struct {
 	val   T
 	delay time.Duration
 }
 
-func (i *debounceInputComparable[T]) Key() T {
-	return i.val
+func (i *debounceInput[T]) Key() string {
+	return ""
 }
 
-func (i *debounceInputComparable[T]) Delay() time.Duration {
+func (i *debounceInput[T]) Delay() time.Duration {
 	return i.delay
 }
 
-func (i *debounceInputComparable[T]) Reduce(*debounceInputComparable[T]) (*debounceInputComparable[T], bool) {
+func (i *debounceInput[T]) Reduce(*debounceInput[T]) (*debounceInput[T], bool) {
 	return i, true
 }
 
-// Debounce reads values from the input channel and pushes them to the returned
-// output channel before, after, or before and after a `delay` debounce period.
+// Debounce reads values from the input channel, and for every distinct debouncing
+// period of `delay` duration, writes a single value to the output channel either
+// before, after, or before and after a `delay` debounce period.
 // The `DebounceType` value used in the function controls when the value is pushed
-// to the output channel.  Any duplicate values read from the input channel during
-// the `delay` debounce period are ignored.
+// to the output channel.  Only the first value read from the input channel at the start
+// of the debounce period will be written to the output channel.
 
 // The channel returned by Debounce is unbuffered by default.
 // When the input channel is closed, any remaining values being delayed/debounced
@@ -68,16 +34,16 @@ func (i *debounceInputComparable[T]) Reduce(*debounceInputComparable[T]) (*debou
 
 // Debounce also returns a function which returns the number of debounced values
 // that are currently being delayed
-func Debounce[T comparable](inc <-chan T, delay time.Duration, opts ...Option[DebounceConfig]) (<-chan T, func() int) {
+func Debounce[T any](inc <-chan T, delay time.Duration, opts ...Option[DebounceConfig]) (<-chan T, func() int) {
 	cfg := parseOpts(opts...)
 
 	outc := make(chan T, cfg.capacity)
 
-	inBridge := make(chan *debounceInputComparable[T])
+	inBridge := make(chan *debounceInput[T])
 	go func() {
 		defer close(inBridge)
 		for in := range inc {
-			inBridge <- &debounceInputComparable[T]{val: in, delay: delay}
+			inBridge <- &debounceInput[T]{val: in, delay: delay}
 		}
 	}()
 
@@ -92,126 +58,4 @@ func Debounce[T comparable](inc <-chan T, delay time.Duration, opts ...Option[De
 	}()
 
 	return outc, getDebouncedCount
-}
-
-// DebounceCustom is like Debounce but with per-item configurability over
-// comparisons, delays, and reducing multiple values to a single debounced value.
-// Where Debounce requires `comparable` values in the input channel,
-// DebounceCustom requires types that implement the `DebounceInput[K comparable, T Keyable[K]]`
-// interface.
-
-// The channel returned by DebounceCustom is unbuffered by default.
-// When the input channel is closed, any remaining values being delayed/debounced
-// will be flushed to the output channel and the output channel will be closed.
-
-// DebounceCustom also returns a function which returns the number of debounced values
-// that are currently being delayed
-func DebounceCustom[K comparable, T DebounceInput[K, T]](inc <-chan T, opts ...Option[DebounceConfig]) (<-chan T, func() int) {
-	cfg := parseOpts(append(defaultDebounceOptions(), opts...)...)
-
-	outc := make(chan T, cfg.capacity)
-	done := make(chan struct{})
-	panicProvider := cfg.panicProvider
-	statsProvider := cfg.statsProvider
-	debounceType := cfg.debounceType
-
-	// the buffer stores a map of key value pairs of
-	// items from the input channel currently being debounced
-	buffer := debounceBuffer[K, T]{
-		data: make(map[K]*debounceItem[K, T]),
-	}
-
-	go func() {
-		defer tryHandlePanic(panicProvider)
-		defer close(outc)
-
-		var wg sync.WaitGroup
-		for next := range inc {
-			key := next.Key()
-			if buffer.add(key, next) {
-				wg.Add(1)
-
-				go func(key K, delay time.Duration) {
-					defer tryHandlePanic(panicProvider)
-					defer wg.Done()
-
-					start := time.Now()
-
-					timer := time.NewTimer(delay)
-					select {
-					case <-done:
-						timer.Stop()
-					case <-timer.C:
-					}
-
-					duration := time.Since(start)
-					item, count := buffer.remove(key)
-
-					if debounceType&TailDebounceType == TailDebounceType {
-						outc <- item
-					}
-					tryProvideStats(DebounceStats{Delay: duration, Count: count}, statsProvider)
-				}(key, next.Delay())
-
-				if debounceType&LeadDebounceType == LeadDebounceType {
-					outc <- next
-				}
-			}
-		}
-
-		close(done)
-		wg.Wait()
-	}()
-
-	return outc, buffer.len
-}
-
-type debounceItem[K comparable, T DebounceInput[K, T]] struct {
-	value T
-	count uint
-}
-
-// debounceBuffer stores debounced values and counts
-type debounceBuffer[K comparable, T DebounceInput[K, T]] struct {
-	data map[K]*debounceItem[K, T]
-	sync.Mutex
-}
-
-func (buffer *debounceBuffer[K, T]) add(key K, value T) bool {
-	buffer.Lock()
-	defer buffer.Unlock()
-
-	if existing, hasExistingValue := buffer.data[key]; hasExistingValue {
-		existing.count++
-
-		value, ok := existing.value.Reduce(value)
-		if ok {
-			existing.value = value
-		}
-		return false
-	}
-
-	buffer.data[key] = &debounceItem[K, T]{
-		value: value,
-		count: 1,
-	}
-
-	return true
-}
-
-func (buffer *debounceBuffer[K, T]) remove(key K) (T, uint) {
-	buffer.Lock()
-	defer buffer.Unlock()
-
-	item := buffer.data[key]
-	delete(buffer.data, key)
-
-	return item.value, item.count
-}
-
-func (buffer *debounceBuffer[K, T]) len() int {
-	buffer.Lock()
-	defer buffer.Unlock()
-
-	return len(buffer.data)
 }

--- a/debounce_custom.go
+++ b/debounce_custom.go
@@ -1,0 +1,156 @@
+package channels
+
+import (
+	"sync"
+	"time"
+
+	"github.com/jonabc/channels/providers"
+)
+
+type DebounceType byte
+
+const (
+	TailDebounceType DebounceType = 1 << iota
+	LeadDebounceType
+	LeadTailDebounceType = TailDebounceType | LeadDebounceType
+)
+
+// DebounceConfig contains user configurable options for the Debounce functions
+type DebounceConfig struct {
+	panicProvider providers.Provider[any]
+	statsProvider providers.Provider[DebounceStats]
+	capacity      int
+	debounceType  DebounceType
+}
+
+func defaultDebounceOptions() []Option[DebounceConfig] {
+	return []Option[DebounceConfig]{
+		DebounceTypeOption(TailDebounceType),
+	}
+}
+
+type Keyable[K comparable] interface {
+	Key() K
+}
+
+type DebounceInput[K comparable, T Keyable[K]] interface {
+	Keyable[K]
+	Delay() time.Duration
+	Reduce(T) (T, bool)
+}
+
+// DebounceCustom is like Debounce but with per-item configurability over
+// comparisons, delays, and reducing multiple values to a single debounced value.
+// Where Debounce requires `comparable` values in the input channel,
+// DebounceCustom requires types that implement the `DebounceInput[K comparable, T Keyable[K]]`
+// interface.
+func DebounceCustom[K comparable, T DebounceInput[K, T]](inc <-chan T, opts ...Option[DebounceConfig]) (<-chan T, func() int) {
+	cfg := parseOpts(append(defaultDebounceOptions(), opts...)...)
+
+	outc := make(chan T, cfg.capacity)
+	done := make(chan struct{})
+	panicProvider := cfg.panicProvider
+	statsProvider := cfg.statsProvider
+	debounceType := cfg.debounceType
+
+	// the buffer stores a map of key value pairs of
+	// items from the input channel currently being debounced
+	buffer := debounceBuffer[K, T]{
+		data: make(map[K]*debounceItem[K, T]),
+	}
+
+	go func() {
+		defer tryHandlePanic(panicProvider)
+		defer close(outc)
+
+		var wg sync.WaitGroup
+		for next := range inc {
+			key := next.Key()
+			if buffer.add(key, next) {
+				wg.Add(1)
+
+				go func(key K, delay time.Duration) {
+					defer tryHandlePanic(panicProvider)
+					defer wg.Done()
+
+					start := time.Now()
+
+					timer := time.NewTimer(delay)
+					select {
+					case <-done:
+						timer.Stop()
+					case <-timer.C:
+					}
+
+					duration := time.Since(start)
+					item, count := buffer.remove(key)
+
+					if debounceType&TailDebounceType == TailDebounceType {
+						outc <- item
+						tryProvideStats(DebounceStats{Delay: duration, Count: count}, statsProvider)
+					}
+				}(key, next.Delay())
+
+				if debounceType&LeadDebounceType == LeadDebounceType {
+					outc <- next
+					tryProvideStats(DebounceStats{Delay: 0, Count: 1}, statsProvider)
+				}
+			}
+		}
+
+		close(done)
+		wg.Wait()
+	}()
+
+	return outc, buffer.len
+}
+
+type debounceItem[K comparable, T DebounceInput[K, T]] struct {
+	value T
+	count uint
+}
+
+// debounceBuffer stores debounced values and counts
+type debounceBuffer[K comparable, T DebounceInput[K, T]] struct {
+	data map[K]*debounceItem[K, T]
+	sync.Mutex
+}
+
+func (buffer *debounceBuffer[K, T]) add(key K, value T) bool {
+	buffer.Lock()
+	defer buffer.Unlock()
+
+	if existing, hasExistingValue := buffer.data[key]; hasExistingValue {
+		existing.count++
+
+		value, ok := existing.value.Reduce(value)
+		if ok {
+			existing.value = value
+		}
+		return false
+	}
+
+	buffer.data[key] = &debounceItem[K, T]{
+		value: value,
+		count: 1,
+	}
+
+	return true
+}
+
+func (buffer *debounceBuffer[K, T]) remove(key K) (T, uint) {
+	buffer.Lock()
+	defer buffer.Unlock()
+
+	item := buffer.data[key]
+	delete(buffer.data, key)
+
+	return item.value, item.count
+}
+
+func (buffer *debounceBuffer[K, T]) len() int {
+	buffer.Lock()
+	defer buffer.Unlock()
+
+	return len(buffer.data)
+}

--- a/debounce_custom_test.go
+++ b/debounce_custom_test.go
@@ -1,0 +1,160 @@
+package channels_test
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/jonabc/channels"
+	"github.com/jonabc/channels/providers"
+	"github.com/stretchr/testify/require"
+)
+
+type customDebouncingType struct {
+	key   string
+	value string
+	delay time.Duration
+}
+
+func (d *customDebouncingType) Key() string {
+	return d.key
+}
+
+func (d *customDebouncingType) Delay() time.Duration {
+	return d.delay
+}
+
+func (d *customDebouncingType) Reduce(other *customDebouncingType) (*customDebouncingType, bool) {
+	if d.key == "3" {
+		return d, false
+	}
+
+	d.value += "," + other.value
+	return d, true
+}
+
+func TestDebounceCustom(t *testing.T) {
+	t.Parallel()
+
+	inc := make(chan *customDebouncingType, 100)
+	defer close(inc)
+
+	delay := 5 * time.Millisecond
+	outc, getDebouncedCount := channels.DebounceCustom(inc)
+	require.Equal(t, 0, cap(outc))
+
+	start := time.Now()
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		inc <- &customDebouncingType{key: "1", value: "val1", delay: delay}
+		inc <- &customDebouncingType{key: "1", value: "val2", delay: 1 * time.Millisecond}
+		time.Sleep(2 * time.Millisecond)
+
+		// should have one debounced item after pushing "key:1" twice
+		require.Equal(t, 1, getDebouncedCount())
+		inc <- &customDebouncingType{key: "2", value: "val1", delay: delay}
+		inc <- &customDebouncingType{key: "2", value: "val2", delay: 1 * time.Millisecond}
+		inc <- &customDebouncingType{key: "1", value: "val3", delay: 2 * time.Millisecond}
+
+		time.Sleep(2 * time.Millisecond)
+		inc <- &customDebouncingType{key: "3", value: "val1", delay: delay}
+		inc <- &customDebouncingType{key: "3", value: "shouldnotreduce", delay: 1 * time.Millisecond}
+		wg.Wait()
+	}()
+
+	require.Len(t, outc, 0)
+
+	// only the delay for the first element seen on any key counts
+	require.Equal(t, &customDebouncingType{key: "1", value: "val1,val2,val3", delay: delay}, <-outc)
+
+	require.GreaterOrEqual(t, time.Since(start), delay)
+
+	require.Equal(t, 2, getDebouncedCount())
+	require.Equal(t, &customDebouncingType{key: "2", value: "val1,val2", delay: delay}, <-outc)
+	require.GreaterOrEqual(t, time.Since(start), delay+(2*time.Millisecond))
+
+	require.Equal(t, 1, getDebouncedCount())
+	require.Equal(t, &customDebouncingType{key: "3", value: "val1", delay: delay}, <-outc)
+	require.GreaterOrEqual(t, time.Since(start), delay+(4*time.Millisecond))
+}
+
+func TestDebounceCustomAcceptsOptions(t *testing.T) {
+	t.Parallel()
+
+	in := make(chan *customDebouncingType, 100)
+	defer close(in)
+
+	panicProvider, _ := providers.NewProvider[any](0)
+	defer panicProvider.Close()
+
+	out, _ := channels.DebounceCustom(in,
+		channels.ChannelCapacityOption[channels.DebounceConfig](5),
+		channels.PanicProviderOption[channels.DebounceConfig](panicProvider),
+	)
+
+	require.Equal(t, 5, cap(out))
+}
+
+func TestDebounceCustomLeadDebounceTypeOption(t *testing.T) {
+	t.Parallel()
+
+	in := make(chan *customDebouncingType, 100)
+	defer close(in)
+
+	delay := 5 * time.Millisecond
+	out, getDebouncedCount := channels.DebounceCustom(in,
+		channels.DebounceTypeOption(channels.LeadDebounceType),
+	)
+
+	in <- &customDebouncingType{key: "1", value: "1", delay: delay}
+	in <- &customDebouncingType{key: "2", value: "2", delay: delay}
+	start := time.Now()
+	<-out
+	<-out
+	require.Less(t, time.Since(start), delay)
+	require.Equal(t, 2, getDebouncedCount())
+
+	in <- &customDebouncingType{key: "1", value: "1", delay: delay}
+	in <- &customDebouncingType{key: "2", value: "2", delay: delay}
+	select {
+	case <-out:
+		require.FailNow(t, "Unexpected value during throttling period")
+	case <-time.After(delay + 1*time.Millisecond):
+	}
+	require.Equal(t, 0, getDebouncedCount())
+
+	in <- &customDebouncingType{key: "1", value: "1", delay: delay}
+	in <- &customDebouncingType{key: "2", value: "2", delay: delay}
+	start = time.Now()
+	<-out
+	<-out
+	require.Less(t, time.Since(start), delay)
+	require.Equal(t, 2, getDebouncedCount())
+}
+
+func TestDebounceCustomLeadTailDebounceTypeOption(t *testing.T) {
+	t.Parallel()
+
+	in := make(chan *customDebouncingType, 100)
+	defer close(in)
+
+	delay := 5 * time.Millisecond
+	out, getDebouncedCount := channels.DebounceCustom(in,
+		channels.DebounceTypeOption(channels.LeadTailDebounceType),
+	)
+
+	in <- &customDebouncingType{key: "1", value: "1", delay: delay}
+	in <- &customDebouncingType{key: "2", value: "2", delay: delay}
+	start := time.Now()
+	<-out
+	<-out
+	require.Less(t, time.Since(start), delay)
+	require.Equal(t, 2, getDebouncedCount())
+
+	<-out
+	<-out
+	require.Greater(t, time.Since(start), delay)
+	require.Equal(t, 0, getDebouncedCount())
+}

--- a/debounce_values.go
+++ b/debounce_values.go
@@ -1,0 +1,50 @@
+package channels
+
+import "time"
+
+type debounceValuesInput[T comparable] struct {
+	val   T
+	delay time.Duration
+}
+
+func (i *debounceValuesInput[T]) Key() T {
+	return i.val
+}
+
+func (i *debounceValuesInput[T]) Delay() time.Duration {
+	return i.delay
+}
+
+func (i *debounceValuesInput[T]) Reduce(*debounceValuesInput[T]) (*debounceValuesInput[T], bool) {
+	return i, true
+}
+
+// DebounceValues is like Debounce but with per-value debouncing, where
+// each unique value read from the input channel will start a debouncing
+// period for that value.  Any duplicate values read from the input channel
+// during a debouncing period are ignored.
+func DebounceValues[T comparable](inc <-chan T, delay time.Duration, opts ...Option[DebounceConfig]) (<-chan T, func() int) {
+	cfg := parseOpts(opts...)
+
+	outc := make(chan T, cfg.capacity)
+
+	inBridge := make(chan *debounceValuesInput[T])
+	go func() {
+		defer close(inBridge)
+		for in := range inc {
+			inBridge <- &debounceValuesInput[T]{val: in, delay: delay}
+		}
+	}()
+
+	outBridge, getDebouncedCount := DebounceCustom(inBridge,
+		append(opts, ChannelCapacityOption[DebounceConfig](0))...,
+	)
+	go func() {
+		defer close(outc)
+		for out := range outBridge {
+			outc <- out.val
+		}
+	}()
+
+	return outc, getDebouncedCount
+}

--- a/options.go
+++ b/options.go
@@ -151,3 +151,10 @@ func TapStatsProviderOption(provider providers.Provider[TapStats]) Option[TapCon
 		cfg.statsProvider = provider
 	}
 }
+
+// Specify the type of debouncing to a debouncer function - lead, tail, or both.
+func DebounceTypeOption(debounceType DebounceType) Option[DebounceConfig] {
+	return func(cfg *DebounceConfig) {
+		cfg.debounceType = debounceType
+	}
+}

--- a/throttle.go
+++ b/throttle.go
@@ -2,31 +2,20 @@ package channels
 
 import "time"
 
-// Throttle is equivalent to Debounce with `channels.LeadDebounceType.
-// Throttle reads values from the input channel and pushes them to the
-// returned output channel followed by a period of `delay` duration during
-// which any matching values will be throttled and not pushed to the output channel.
-
-// The channel returned by Throttle is unbuffered by default and will be closd when
-// the input channel is drained and closed.
-
-// Throttle also returns a function which returns the number of values
-// that are currently being throttled
+// Throttle is equivalent to Debounce with `channels.LeadDebounceType`.
+// See Debounce for usage details.
 func Throttle[T comparable](inc <-chan T, delay time.Duration, opts ...Option[DebounceConfig]) (<-chan T, func() int) {
 	return Debounce(inc, delay, append(opts, DebounceTypeOption(LeadDebounceType))...)
 }
 
-// ThrottleCustom is equivalent to DebounceCustom with `channels.LeadDebounceType.
-// ThrottleCustom is like Throttle but with per-item configurability over
-// comparisons and delays. Where Throttle requires `comparable` values in
-// the input channel, ThrottleCustom requires types that implement the
-// `DebounceInput[K comparable, T Keyable[K]]` interface.
+// ThrottleValues is equivalent to DebounceValues with `channels.LeadDebounceType`.
+// See DebounceValues for usage details.
+func ThrottleValues[T comparable](inc <-chan T, delay time.Duration, opts ...Option[DebounceConfig]) (<-chan T, func() int) {
+	return DebounceValues(inc, delay, append(opts, DebounceTypeOption(LeadDebounceType))...)
+}
 
-// The channel returned by ThrottleCustom is unbuffered by default and will be closd when
-// the input channel is drained and closed.
-
-// ThrottleCustom also returns a function which returns the number of values
-// that are currently being throttled
+// ThrottleCustom is equivalent to DebounceCustom with `channels.LeadDebounceType`.
+// See DebounceCustom for usage details.
 func ThrottleCustom[K comparable, T DebounceInput[K, T]](inc <-chan T, opts ...Option[DebounceConfig]) (<-chan T, func() int) {
 	return DebounceCustom(inc, append(opts, DebounceTypeOption(LeadDebounceType))...)
 }

--- a/throttle.go
+++ b/throttle.go
@@ -1,0 +1,32 @@
+package channels
+
+import "time"
+
+// Throttle is equivalent to Debounce with `channels.LeadDebounceType.
+// Throttle reads values from the input channel and pushes them to the
+// returned output channel followed by a period of `delay` duration during
+// which any matching values will be throttled and not pushed to the output channel.
+
+// The channel returned by Throttle is unbuffered by default and will be closd when
+// the input channel is drained and closed.
+
+// Throttle also returns a function which returns the number of values
+// that are currently being throttled
+func Throttle[T comparable](inc <-chan T, delay time.Duration, opts ...Option[DebounceConfig]) (<-chan T, func() int) {
+	return Debounce(inc, delay, append(opts, DebounceTypeOption(LeadDebounceType))...)
+}
+
+// ThrottleCustom is equivalent to DebounceCustom with `channels.LeadDebounceType.
+// ThrottleCustom is like Throttle but with per-item configurability over
+// comparisons and delays. Where Throttle requires `comparable` values in
+// the input channel, ThrottleCustom requires types that implement the
+// `DebounceInput[K comparable, T Keyable[K]]` interface.
+
+// The channel returned by ThrottleCustom is unbuffered by default and will be closd when
+// the input channel is drained and closed.
+
+// ThrottleCustom also returns a function which returns the number of values
+// that are currently being throttled
+func ThrottleCustom[K comparable, T DebounceInput[K, T]](inc <-chan T, opts ...Option[DebounceConfig]) (<-chan T, func() int) {
+	return DebounceCustom(inc, append(opts, DebounceTypeOption(LeadDebounceType))...)
+}

--- a/throttle_test.go
+++ b/throttle_test.go
@@ -1,0 +1,79 @@
+package channels_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/jonabc/channels"
+	"github.com/stretchr/testify/require"
+)
+
+func TestThrottle(t *testing.T) {
+	t.Parallel()
+
+	in := make(chan int, 100)
+	defer close(in)
+
+	delay := 5 * time.Millisecond
+	out, getThrottledCount := channels.Throttle(in, delay)
+
+	in <- 1
+	in <- 2
+	start := time.Now()
+	<-out
+	<-out
+	require.Less(t, time.Since(start), delay)
+	require.Equal(t, 2, getThrottledCount())
+
+	in <- 1
+	in <- 2
+	select {
+	case <-out:
+		require.FailNow(t, "Unexpected value during throttling period")
+	case <-time.After(delay + 1*time.Millisecond):
+	}
+	require.Equal(t, 0, getThrottledCount())
+
+	in <- 1
+	in <- 2
+	start = time.Now()
+	<-out
+	<-out
+	require.Less(t, time.Since(start), delay)
+	require.Equal(t, 2, getThrottledCount())
+}
+
+func TestThrottleCustom(t *testing.T) {
+	t.Parallel()
+
+	in := make(chan *customDebouncingType, 100)
+	defer close(in)
+
+	delay := 5 * time.Millisecond
+	out, getThrottledCount := channels.ThrottleCustom(in)
+
+	in <- &customDebouncingType{key: "1", value: "1", delay: delay}
+	in <- &customDebouncingType{key: "2", value: "2", delay: delay}
+	start := time.Now()
+	<-out
+	<-out
+	require.Less(t, time.Since(start), delay)
+	require.Equal(t, 2, getThrottledCount())
+
+	in <- &customDebouncingType{key: "1", value: "1", delay: delay}
+	in <- &customDebouncingType{key: "2", value: "2", delay: delay}
+	select {
+	case <-out:
+		require.FailNow(t, "Unexpected value during throttling period")
+	case <-time.After(delay + 1*time.Millisecond):
+	}
+	require.Equal(t, 0, getThrottledCount())
+
+	in <- &customDebouncingType{key: "1", value: "1", delay: delay}
+	in <- &customDebouncingType{key: "2", value: "2", delay: delay}
+	start = time.Now()
+	<-out
+	<-out
+	require.Less(t, time.Since(start), delay)
+	require.Equal(t, 2, getThrottledCount())
+}


### PR DESCRIPTION
THIS IS A BREAKING CHANGE - the `Debounce` function has been renamed `DebounceValues`, and the new `Debounce` function is agnostic to the values read from the input channel.

This adds a few new pieces of functionality to the debouncing functions
1. Callers can now specify lead, tail, and leadtail debouncing types.  The existing behavior is tail debouncing, which remains the default.
   - Lead debouncing writes a value to the output channel at the start of the debouncing period
   - Tail debouncing writes a value to the output channel at the end of the debouncing period
   - LeadTail debouncing writes a value to the output channel both at the start and end of the debouncing period
2. The addition of `Throttle*` functions mirroring the `Debounce*` functions.  These are helpers for calling `Debounce*` functions with `channels.DebounceTypeOption(LeadDebounceType)`
3. Renamed `Debounce`, a value-specific debouncing function to `DebounceValues`.  `Debounce` is now a value-agnostic debouncing function.  When `Debounce` starts a debouncing period, any and all additional values read from the channel will be ignored until the debouncing period ends.  `Throttle` and `ThrotttleValues` match these behaviors with lead debouncing.