### PR TITLE
DrainValues

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,7 +222,26 @@ count, drained := channels.Drain(inc, 10 * time.Millisecond)
 // count == 3, drained == true
 ```
 
-Drain blocks until either the input channel is fully drained and closed or `maxWait` duration has passed.  Drain returns true when exiting due to the input channel being drained and closed, false when exiting due to waiting for the `maxWait` duration.  When `maxWait <= 0`, Drain will wait forever, and only exit when the input channel is closed.
+Drain blocks until either the input channel is fully drained and closed or `maxWait` duration has passed.  Drain returns the count of values drained from the channel, and a bool that is true when exiting due to the input channel being drained and closed or false when exiting due to waiting for the `maxWait` duration.  When `maxWait <= 0`, Drain will wait forever, and only exit when the input channel is closed.
+
+### DrainValues (Blocking)
+
+```go
+// signature
+func DrainValues[T any](inc <-chan TIn, maxWait time.Duration) ([]TIn, bool)
+
+// usage
+inc := make(chan int)
+inc <- 1
+inc <- 2
+inc <- 3
+close(inc)
+
+values, drained := channels.Drain(inc, 10 * time.Millisecond)
+// valued == []int{1,2,3}, drained == true
+```
+
+DrainValues blocks until either the input channel is fully drained and closed or `maxWait` duration has passed.  DrainValues returns the values drained from the channel, and a bool that is true when exiting due to the input channel being drained and closed or false when exiting due to waiting for the `maxWait` duration.  When `maxWait <= 0`, Drain will wait forever, and only exit when the input channel is closed.
 
 ### FlatMap
 

--- a/drain.go
+++ b/drain.go
@@ -7,8 +7,8 @@ import (
 )
 
 // Drain blocks until either the input channel is fully drained and closed or `maxWait` duration has passed.
-// Drain returns true when exiting due to the input channel being drained and closed, false when exiting
-// due to waiting for the `maxWait` duration.
+// Drain returns the count of values drained from the channel, and a bool that is true when exiting due to
+// the input channel being drained and closed or false when exiting due to waiting for the `maxWait` duration.
 // When `maxWait <= 0`, Drain will wait forever, and only exit when the input channel is closed.
 func Drain[T any](inc <-chan T, maxWait time.Duration) (int, bool) {
 	ticker := internalTime.NewTicker(maxWait)
@@ -25,6 +25,29 @@ func Drain[T any](inc <-chan T, maxWait time.Duration) (int, bool) {
 			count++
 		case <-ticker.C:
 			return count, false
+		}
+	}
+}
+
+// DrainValues blocks until either the input channel is fully drained and closed or `maxWait` duration has passed.
+// DrainValues returns the values drained from the channel, and a bool that is true when exiting due to
+// the input channel being drained and closed or false when exiting due to waiting for the `maxWait` duration.
+// When `maxWait <= 0`, Drain will wait forever, and only exit when the input channel is closed.
+func DrainValues[T any](inc <-chan T, maxWait time.Duration) ([]T, bool) {
+	ticker := internalTime.NewTicker(maxWait)
+	defer ticker.Stop()
+
+	values := []T{}
+
+	for {
+		select {
+		case val, ok := <-inc:
+			if !ok {
+				return values, true
+			}
+			values = append(values, val)
+		case <-ticker.C:
+			return values, false
 		}
 	}
 }

--- a/drain_test.go
+++ b/drain_test.go
@@ -41,3 +41,37 @@ func TestDrainReturnsFalseWhenMaxWaitElapses(t *testing.T) {
 	require.Equal(t, 0, count)
 	require.False(t, drained)
 }
+
+func TestDrainValuesReturnsTrueWhenChannelIsDrainedAndClosed(t *testing.T) {
+	t.Parallel()
+
+	in := make(chan int, 10)
+	go func() {
+		time.Sleep(20 * time.Millisecond)
+		in <- 1
+		in <- 2
+		in <- 3
+		close(in)
+	}()
+
+	values, drained := channels.DrainValues(in, 0)
+	require.Equal(t, []int{1, 2, 3}, values)
+	require.True(t, drained)
+}
+
+func TestDrainValuesReturnsFalseWhenMaxWaitElapses(t *testing.T) {
+	t.Parallel()
+
+	in := make(chan int, 10)
+	go func() {
+		time.Sleep(20 * time.Millisecond)
+		in <- 1
+		in <- 2
+		in <- 3
+		close(in)
+	}()
+
+	values, drained := channels.DrainValues(in, 2*time.Millisecond)
+	require.Empty(t, values)
+	require.False(t, drained)
+}


### PR DESCRIPTION
like Drain, but returns values instead of counts.  The default, unsuffixed Drain continues to return only a count of values drained due to returning values potentially being memory intensive.