### PR TITLE
Add void function to consume channels

### DIFF
--- a/README.md
+++ b/README.md
@@ -732,6 +732,24 @@ inc <- &myType{key:"1", val: 1, delay: delay}
 
 ThrottleCustom is equivalent to [DebounceCustom](#debouncecustom) with `channels.LeadDebounceType`.
 
+### Void
+
+```go
+// signature
+Void[T any](inc <-chan T)
+
+// usage
+inc := make(chan int, 2)
+channels.Void(inc)
+
+inc <- 1
+inc <- 2
+
+// and they're gone
+```
+
+Void consumes a channel with no other action taken.  This function can be useful for tests or while iteratively composing a channel pipeline before the final consumption of channel events is completed.
+
 ### WithDone
 
 ```go

--- a/void.go
+++ b/void.go
@@ -1,0 +1,9 @@
+package channels
+
+// Void consumes a channel until it is closed, doing nothing with the channel items.
+func Void[T any](inc <-chan T) {
+	go func() {
+		for range inc {
+		}
+	}()
+}

--- a/void_test.go
+++ b/void_test.go
@@ -1,0 +1,26 @@
+package channels_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/jonabc/channels"
+	"github.com/stretchr/testify/require"
+)
+
+func TestVoid(t *testing.T) {
+	t.Parallel()
+
+	in := make(chan int, 10)
+	defer close(in)
+
+	channels.Void(in)
+
+	in <- 1
+	in <- 2
+
+	// Void starts a goroutine, sleep for a small period of time here
+	// to ensure that the goroutine has time to consume the channel
+	time.Sleep(100 * time.Microsecond)
+	require.Len(t, in, 0)
+}


### PR DESCRIPTION
Consume the incoming channel until it is closed, sending consumed items to the void.