### PR TITLE
feat: Delay function

### DIFF
--- a/debounce_custom.go
+++ b/debounce_custom.go
@@ -35,7 +35,7 @@ type Keyable[K comparable] interface {
 
 type DebounceInput[K comparable, T Keyable[K]] interface {
 	Keyable[K]
-	Delay() time.Duration
+	Delayable
 	Reduce(T) (T, bool)
 }
 

--- a/delay.go
+++ b/delay.go
@@ -1,0 +1,40 @@
+package channels
+
+import (
+	"time"
+)
+
+// Delay reads values from the input channel, and writes each value to the
+// output channel after `delay` duration.
+
+// The channel returned by Delay is unbuffered by default.
+// When the input channel is closed, any remaining values being delayed
+// will be flushed to the output channel and the output channel will be closed.
+
+// Delay also returns a function which returns the number of values
+// that are currently being delayed.
+func Delay[T any](inc <-chan T, delay time.Duration, opts ...Option[DelayConfig]) (<-chan T, func() int) {
+	cfg := parseOpts(opts...)
+
+	outc := make(chan T, cfg.capacity)
+
+	inBridge := make(chan *debounceInput[T])
+	go func() {
+		defer close(inBridge)
+		for in := range inc {
+			inBridge <- &debounceInput[T]{val: in, delay: delay}
+		}
+	}()
+
+	outBridge, getDelayedCount := DelayCustom(inBridge,
+		append(opts, ChannelCapacityOption[DelayConfig](0))...,
+	)
+	go func() {
+		defer close(outc)
+		for out := range outBridge {
+			outc <- out.val
+		}
+	}()
+
+	return outc, getDelayedCount
+}

--- a/delay_custom.go
+++ b/delay_custom.go
@@ -1,0 +1,67 @@
+package channels
+
+import (
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/jonabc/channels/providers"
+)
+
+// DelayConfig contains user configurable options for the Delay functions
+type DelayConfig struct {
+	panicProvider providers.Provider[any]
+	statsProvider providers.Provider[Stats]
+	capacity      int
+}
+
+type Delayable interface {
+	Delay() time.Duration
+}
+
+// DelayCustom is like Delay but with per-item configurability over delays.
+// Where DelayCustom requires types that implement the `Delayable`
+// interface.
+func DelayCustom[T Delayable](inc <-chan T, opts ...Option[DelayConfig]) (<-chan T, func() int) {
+	cfg := parseOpts(opts...)
+
+	outc := make(chan T, cfg.capacity)
+	done := make(chan struct{})
+	panicProvider := cfg.panicProvider
+	statsProvider := cfg.statsProvider
+
+	var count atomic.Int32
+	go func() {
+		defer tryHandlePanic(panicProvider)
+		defer close(outc)
+
+		var wg sync.WaitGroup
+		for next := range inc {
+			wg.Add(1)
+			count.Add(1)
+			go func(item T) {
+				defer tryHandlePanic(panicProvider)
+				defer count.Add(-1)
+				defer wg.Done()
+
+				delay := item.Delay()
+				if delay > 0 {
+					timer := time.NewTimer(delay)
+					select {
+					case <-done:
+						timer.Stop()
+					case <-timer.C:
+					}
+				}
+
+				outc <- item
+				tryProvideStats(Stats{Duration: delay, QueueLength: len(inc)}, statsProvider)
+			}(next)
+		}
+
+		close(done)
+		wg.Wait()
+	}()
+
+	return outc, func() int { return int(count.Load()) }
+}

--- a/delay_custom_test.go
+++ b/delay_custom_test.go
@@ -1,0 +1,52 @@
+package channels_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/jonabc/channels"
+	"github.com/jonabc/channels/providers"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDelayCustom(t *testing.T) {
+	t.Parallel()
+
+	inc := make(chan *customDebouncingType, 100)
+	defer close(inc)
+
+	delay := 5 * time.Millisecond
+	outc, getDelayedCount := channels.DelayCustom(inc)
+	require.Equal(t, 0, cap(outc))
+
+	start := time.Now()
+
+	input := &customDebouncingType{key: "1", value: "val1", delay: delay}
+	inc <- input
+
+	// sleep to allow delay subroutine to intake the value
+	time.Sleep(1 * time.Millisecond)
+	require.Equal(t, getDelayedCount(), 1)
+
+	val, ok := <-outc
+	require.True(t, ok)
+	require.Equal(t, input, val)
+	require.GreaterOrEqual(t, time.Since(start), delay)
+}
+
+func TestDelayCustomAcceptsOptions(t *testing.T) {
+	t.Parallel()
+
+	in := make(chan *customDebouncingType, 100)
+	defer close(in)
+
+	panicProvider, _ := providers.NewProvider[any](0)
+	defer panicProvider.Close()
+
+	out, _ := channels.DelayCustom(in,
+		channels.ChannelCapacityOption[channels.DelayConfig](5),
+		channels.PanicProviderOption[channels.DelayConfig](panicProvider),
+	)
+
+	require.Equal(t, 5, cap(out))
+}

--- a/delay_test.go
+++ b/delay_test.go
@@ -1,0 +1,74 @@
+package channels_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/jonabc/channels"
+	"github.com/jonabc/channels/providers"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDelay(t *testing.T) {
+	t.Parallel()
+
+	inc := make(chan int, 10)
+	defer close(inc)
+
+	delay := 5 * time.Millisecond
+	outc, getDelayedCount := channels.Delay(inc, delay)
+	require.Equal(t, 0, cap(outc))
+
+	start := time.Now()
+
+	inc <- 1
+
+	// sleep to allow delay subroutine to intake the value
+	time.Sleep(1 * time.Millisecond)
+	require.Equal(t, getDelayedCount(), 1)
+
+	val, ok := <-outc
+	require.True(t, ok)
+	require.Equal(t, 1, val)
+	require.GreaterOrEqual(t, time.Since(start), delay)
+}
+
+func TestDelayAcceptsOptions(t *testing.T) {
+	t.Parallel()
+
+	in := make(chan int, 100)
+	defer close(in)
+
+	panicProvider, _ := providers.NewProvider[any](0)
+	defer panicProvider.Close()
+
+	out, _ := channels.Delay(in, 2*time.Millisecond,
+		channels.ChannelCapacityOption[channels.DelayConfig](5),
+		channels.PanicProviderOption[channels.DelayConfig](panicProvider),
+	)
+
+	require.Equal(t, 5, cap(out))
+}
+
+func TestDelayProviderOptionWithStatsReporting(t *testing.T) {
+	t.Parallel()
+
+	in := make(chan int, 100)
+	defer close(in)
+
+	provider, receiver := providers.NewCollectingProvider[channels.Stats](0)
+	defer provider.Close()
+
+	delay := 5 * time.Millisecond
+	out, _ := channels.Delay(in, delay,
+		channels.StatsProviderOption[channels.DelayConfig](provider),
+	)
+
+	in <- 1
+	<-out
+
+	stats, ok := <-receiver.Channel()
+	require.True(t, ok)
+	require.Len(t, stats, 1)
+	require.GreaterOrEqual(t, stats[0].Duration, delay)
+}

--- a/options.go
+++ b/options.go
@@ -7,6 +7,7 @@ import (
 type channelConfiguration interface {
 	BatchConfig |
 		DebounceConfig |
+		DelayConfig |
 		EachConfig |
 		FlatMapConfig |
 		MapConfig |
@@ -26,6 +27,8 @@ func PanicProviderOption[T channelConfiguration](provider providers.Provider[any
 		case *BatchConfig:
 			cfg.panicProvider = provider
 		case *DebounceConfig:
+			cfg.panicProvider = provider
+		case *DelayConfig:
 			cfg.panicProvider = provider
 		case *EachConfig:
 			cfg.panicProvider = provider
@@ -50,6 +53,7 @@ func PanicProviderOption[T channelConfiguration](provider providers.Provider[any
 type singleOutputConfiguration interface {
 	BatchConfig |
 		DebounceConfig |
+		DelayConfig |
 		FlatMapConfig |
 		MapConfig |
 		MergeConfig |
@@ -66,6 +70,8 @@ func ChannelCapacityOption[T singleOutputConfiguration](capacity int) Option[T] 
 		case *BatchConfig:
 			cfg.capacity = capacity
 		case *DebounceConfig:
+			cfg.capacity = capacity
+		case *DelayConfig:
 			cfg.capacity = capacity
 		case *FlatMapConfig:
 			cfg.capacity = capacity
@@ -109,7 +115,8 @@ func parseOpts[C any, O ~func(*C)](opts ...O) *C {
 }
 
 type statsConfiguration interface {
-	EachConfig |
+	DelayConfig |
+		EachConfig |
 		FlatMapConfig |
 		MapConfig |
 		ReduceConfig |
@@ -120,6 +127,8 @@ type statsConfiguration interface {
 func StatsProviderOption[T statsConfiguration](provider providers.Provider[Stats]) Option[T] {
 	return func(cfg *T) {
 		switch cfg := any(cfg).(type) {
+		case *DelayConfig:
+			cfg.statsProvider = provider
 		case *EachConfig:
 			cfg.statsProvider = provider
 		case *FlatMapConfig:


### PR DESCRIPTION
Delays input values for specified periods of time.  Similar to Debounce, supports constant delay as well as delay-per-item.