### PR TITLE
Feat: batching of unique values

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,11 +21,11 @@ Providers and receivers wrap channels to provide a few quality of life benefits.
 
 ```go
 // signature
-func Batch[T any](inc <-chan T, batchSize int) <- chan T
+func Batch[T any](inc <-chan T, batchSize int, maxDelay time.Duration) <- chan T
 
 // usage
 inc := make(chan int)
-outc := Batch(inc, 2)
+outc := Batch(inc, 2, 0)
 
 inc <- 1
 inc <- 2
@@ -41,7 +41,7 @@ Batch N values from the input channel into an array of N values in the output ch
 
 ```go
 // signature
-func BatchValues[T any](inc <-chan T, batchSize int) [][]T
+func BatchValues[T any](inc <-chan T, batchSize int, maxDelay time.Duration) [][]T
 
 // usage
 inc := make(chan int, 4)
@@ -51,7 +51,7 @@ inc <- 3
 inc <- 4
 close(inc)
 
-results := BatchValues(inc, 2)
+results := BatchValues(inc, 2, 0)
 // results == [][]int{{1,2}, {3,4}}
 ```
 

--- a/batch_test.go
+++ b/batch_test.go
@@ -164,7 +164,7 @@ func TestBatchProviderOptionWithStatsReporting(t *testing.T) {
 	stats, ok := <-receiver.Channel()
 	require.True(t, ok)
 	require.Len(t, stats, 1)
-	require.Greater(t, stats[0].Duration, time.Duration(0))
+	require.GreaterOrEqual(t, stats[0].Duration, time.Duration(0))
 	require.Equal(t, uint(2), stats[0].BatchSize)
 	require.Equal(t, 1, stats[0].QueueLength)
 
@@ -173,7 +173,7 @@ func TestBatchProviderOptionWithStatsReporting(t *testing.T) {
 	stats, ok = <-receiver.Channel()
 	require.True(t, ok)
 	require.Len(t, stats, 1)
-	require.Greater(t, stats[0].Duration, 2*time.Millisecond)
+	require.GreaterOrEqual(t, stats[0].Duration, 2*time.Millisecond)
 	require.Equal(t, uint(1), stats[0].BatchSize)
 	require.Equal(t, 0, stats[0].QueueLength)
 }

--- a/debounce_custom_test.go
+++ b/debounce_custom_test.go
@@ -155,6 +155,6 @@ func TestDebounceCustomLeadTailDebounceTypeOption(t *testing.T) {
 
 	<-out
 	<-out
-	require.Greater(t, time.Since(start), delay)
+	require.GreaterOrEqual(t, time.Since(start), delay)
 	require.Equal(t, 0, getDebouncedCount())
 }

--- a/debounce_test.go
+++ b/debounce_test.go
@@ -83,7 +83,7 @@ func TestDebounceProviderOptionWithStatsReporting(t *testing.T) {
 	stats, ok := <-receiver.Channel()
 	require.True(t, ok)
 	require.Len(t, stats, 1)
-	require.Greater(t, stats[0].Delay, 5*time.Millisecond)
+	require.GreaterOrEqual(t, stats[0].Delay, 5*time.Millisecond)
 	require.Equal(t, uint(2), stats[0].Count)
 }
 
@@ -140,6 +140,6 @@ func TestDebounceLeadTailDebounceTypeOption(t *testing.T) {
 	require.Equal(t, 1, getDebouncedCount())
 
 	<-out
-	require.Greater(t, time.Since(start), delay)
+	require.GreaterOrEqual(t, time.Since(start), delay)
 	require.Equal(t, 0, getDebouncedCount())
 }

--- a/debounce_values_test.go
+++ b/debounce_values_test.go
@@ -94,7 +94,7 @@ func TestDebounceValuesProviderOptionWithStatsReporting(t *testing.T) {
 	stats, ok := <-receiver.Channel()
 	require.True(t, ok)
 	require.Len(t, stats, 1)
-	require.Greater(t, stats[0].Delay, 5*time.Millisecond)
+	require.GreaterOrEqual(t, stats[0].Delay, 5*time.Millisecond)
 	require.Equal(t, uint(2), stats[0].Count)
 
 	in <- 1
@@ -165,6 +165,6 @@ func TestDebounceValuesLeadTailDebounceTypeOption(t *testing.T) {
 
 	<-out
 	<-out
-	require.Greater(t, time.Since(start), delay)
+	require.GreaterOrEqual(t, time.Since(start), delay)
 	require.Equal(t, 0, getDebouncedCount())
 }

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,10 @@ module github.com/jonabc/channels
 
 go 1.21
 
-require github.com/stretchr/testify v1.9.0
+require (
+	github.com/stretchr/testify v1.9.0
+	golang.org/x/exp v0.0.0-20240506185415-9bf2ced13842
+)
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -4,6 +4,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
+golang.org/x/exp v0.0.0-20240506185415-9bf2ced13842 h1:vr/HnozRka3pE4EsMEg1lgkXJkTFJCVUX+S/ZT6wYzM=
+golang.org/x/exp v0.0.0-20240506185415-9bf2ced13842/go.mod h1:XtvwrStGgqGPLc4cjQfWqZHG1YFdYs6swckp8vpsjnc=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=

--- a/unique.go
+++ b/unique.go
@@ -1,0 +1,129 @@
+package channels
+
+import (
+	"time"
+
+	internalTime "github.com/jonabc/channels/internal/time"
+	"golang.org/x/exp/maps"
+)
+
+type keyedWrapper[T comparable] struct {
+	val T
+}
+
+func (w *keyedWrapper[T]) Key() T {
+	return w.val
+}
+
+// Batch unique values from the input channel into an array of values written to the output channel.
+// The output channel is unbuffered by default, and will be closed when the input channel
+// is closed and drained.  If a partial batch exists when the input channel is closed,
+// the partial batch will be sent to the output channel.
+func Unique[T comparable](inc <-chan T, batchSize int, maxDelay time.Duration, opts ...Option[BatchConfig]) <-chan []T {
+	cfg := parseOpts(opts...)
+
+	outc := make(chan []T, cfg.capacity)
+
+	inBridge := make(chan *keyedWrapper[T])
+	go func() {
+		defer close(inBridge)
+		for in := range inc {
+			inBridge <- &keyedWrapper[T]{val: in}
+		}
+	}()
+
+	outBridge := UniqueKeyed(inBridge, batchSize, maxDelay,
+		append(opts, ChannelCapacityOption[BatchConfig](0))...,
+	)
+	go func() {
+		defer close(outc)
+		for out := range outBridge {
+			vals := make([]T, len(out))
+			for i, wrapper := range out {
+				vals[i] = wrapper.val
+			}
+
+			outc <- vals
+		}
+	}()
+
+	return outc
+}
+
+// Batch unique values from the input channel into an array of values written to the output channel.  Uniqueness is determed
+// by the value returned by each value's Key() function.
+// The output channel is unbuffered by default, and will be closed when the input channel
+// is closed and drained.  If a partial batch exists when the input channel is closed,
+// the partial batch will be sent to the output channel.
+func UniqueKeyed[K comparable, V Keyable[K]](inc <-chan V, batchSize int, maxDelay time.Duration, opts ...Option[BatchConfig]) <-chan []V {
+	cfg := parseOpts(opts...)
+
+	outc := make(chan []V, cfg.capacity)
+	panicProvider := cfg.panicProvider
+	statsProvider := cfg.statsProvider
+
+	buffer := make(map[K]V, batchSize)
+
+	timer := internalTime.NewTimer(maxDelay)
+	timer.Stop()
+
+	var batchStart time.Time
+
+	publishAndReset := func() {
+		timer.Stop()
+		if len(buffer) == 0 {
+			return
+		}
+
+		duration := time.Since(batchStart)
+		batchSize := len(buffer)
+
+		keys := maps.Values(buffer)
+		outc <- keys
+		clear(buffer)
+		tryProvideStats(BatchStats{Duration: duration, BatchSize: uint(batchSize), QueueLength: len(inc)}, statsProvider)
+	}
+
+	go func() {
+		defer tryHandlePanic(panicProvider)
+		defer close(outc)
+		defer timer.Stop()
+
+		for {
+			select {
+			case in, ok := <-inc:
+				if !ok {
+					publishAndReset()
+					return
+				}
+
+				if len(buffer) == 0 {
+					timer.Reset(maxDelay)
+					batchStart = time.Now()
+				}
+
+				buffer[in.Key()] = in
+				if len(buffer) == batchSize {
+					publishAndReset()
+				}
+			case <-timer.C:
+				publishAndReset()
+			}
+		}
+	}()
+
+	return outc
+}
+
+// Like Unique, but blocks until the input channel is closed and all values are read.
+// UniqueValues reads all values from the input channel and returns an array of batches.
+func UniqueValues[T comparable](inc <-chan T, batchSize int, maxDelay time.Duration, opts ...Option[BatchConfig]) [][]T {
+	outc := Unique(inc, batchSize, maxDelay, opts...)
+	result := make([][]T, 0, len(inc))
+
+	for out := range outc {
+		result = append(result, out)
+	}
+
+	return result
+}

--- a/unique_test.go
+++ b/unique_test.go
@@ -1,0 +1,194 @@
+package channels_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/jonabc/channels"
+	"github.com/jonabc/channels/providers"
+)
+
+func TestUniqueAfterMaxBatchSize(t *testing.T) {
+	t.Parallel()
+
+	in := make(chan int, 10)
+
+	batchSize := 5
+	out := channels.Unique(in, batchSize, 0)
+
+	require.Equal(t, 0, cap(out))
+
+	go func() {
+		defer close(in)
+		for i := 1; i <= 2*cap(in); i++ {
+			in <- i
+
+			// Avoid sending a duplicate of the last item in a batch,
+			// the first write of the item will trigger sending a batch
+			// and the duplicate will end up starting a new batch.  This
+			// makes validation harder for minimal added value, uniqueness
+			// is still validated for all other items in each batch
+			if i%batchSize != 0 {
+				in <- i
+			}
+		}
+	}()
+
+	i := 0
+	for batch := range out {
+		expected := make([]int, 0, batchSize)
+		for j := i * batchSize; j < (i+1)*batchSize; j++ {
+			expected = append(expected, j+1)
+		}
+		require.ElementsMatch(t, batch, expected)
+		i++
+	}
+
+	require.Len(t, in, 0)
+	require.Len(t, out, 0)
+	_, ok := <-out
+	require.False(t, ok)
+}
+
+func TestUniqueValuesAfterMaxBatchSize(t *testing.T) {
+	t.Parallel()
+
+	batchSize := 5
+	in := make(chan int, 10)
+
+	go func() {
+		defer close(in)
+		for i := 1; i <= cap(in); i++ {
+			in <- i
+
+			// Avoid sending a duplicate of the last item in a batch,
+			// the first write of the item will trigger sending a batch
+			// and the duplicate will end up starting a new batch.  This
+			// makes validation harder for minimal added value, uniqueness
+			// is still validated for all other items in each batch
+			if i%batchSize != 0 {
+				in <- i
+			}
+		}
+	}()
+
+	out := channels.UniqueValues(in, batchSize, 0)
+	require.Equal(t, cap(in)/batchSize, len(out))
+
+	for i, batch := range out {
+		expected := make([]int, 0, batchSize)
+		for j := i * batchSize; j < i*batchSize+batchSize; j++ {
+			expected = append(expected, j+1)
+		}
+		require.ElementsMatch(t, batch, expected)
+	}
+}
+
+func TestUniqueAfterMaxDelay(t *testing.T) {
+	t.Parallel()
+
+	in := make(chan int, 100)
+	defer close(in)
+
+	batchSize := 2
+	maxDelay := 5 * time.Millisecond
+	out := channels.Unique(in, batchSize, maxDelay)
+
+	in <- 1
+	in <- 1
+
+	require.Equal(t, <-out, []int{1})
+}
+
+func TestUniqueValuesAfterMaxDelay(t *testing.T) {
+	t.Parallel()
+
+	in := make(chan int, 100)
+
+	batchSize := 2
+	maxDelay := 5 * time.Millisecond
+	go func() {
+		in <- 1
+		in <- 1
+		time.Sleep(maxDelay + 2*time.Millisecond)
+		in <- 2
+		in <- 2
+		close(in)
+	}()
+
+	out := channels.UniqueValues(in, batchSize, maxDelay)
+
+	require.Equal(t, [][]int{{1}, {2}}, out)
+}
+
+func TestUniqueDrainsItemsOnInputChannelClose(t *testing.T) {
+	t.Parallel()
+
+	in := make(chan int, 100)
+
+	batchSize := 2
+	out := channels.Unique(in, batchSize, 0)
+
+	in <- 1
+	in <- 1
+
+	close(in)
+
+	require.Equal(t, <-out, []int{1})
+}
+
+func TestUniqueDoesNotDrainEmptyBatchOnChannelClose(t *testing.T) {
+	t.Parallel()
+
+	in := make(chan int, 100)
+
+	batchSize := 2
+	out := channels.Unique(in, batchSize, 0)
+
+	close(in)
+	time.Sleep(1 * time.Millisecond)
+
+	require.Len(t, out, 0)
+}
+
+func TestUniqueChannelCapacityOption(t *testing.T) {
+	t.Parallel()
+
+	in := make(chan int, 100)
+	defer close(in)
+	outCapacity := 1
+
+	out := channels.Unique(in, 5, 0,
+		channels.ChannelCapacityOption[channels.BatchConfig](outCapacity),
+	)
+
+	require.Equal(t, outCapacity, cap(out))
+}
+
+func TestUniqueProviderOptionWithStatsReporting(t *testing.T) {
+	t.Parallel()
+
+	in := make(chan int, 100)
+	defer close(in)
+
+	provider, receiver := providers.NewCollectingProvider[channels.BatchStats](0)
+	defer provider.Close()
+
+	out := channels.Unique(in, 2, 2*time.Millisecond,
+		channels.BatchStatsProviderOption(provider),
+	)
+
+	in <- 1
+	in <- 2
+	in <- 1
+	<-out
+
+	stats, ok := <-receiver.Channel()
+	require.True(t, ok)
+	require.Len(t, stats, 1)
+	require.GreaterOrEqual(t, stats[0].Duration, time.Duration(0))
+	require.Equal(t, uint(2), stats[0].BatchSize)
+	require.Equal(t, 0, stats[0].QueueLength)
+}

--- a/void_test.go
+++ b/void_test.go
@@ -21,6 +21,6 @@ func TestVoid(t *testing.T) {
 
 	// Void starts a goroutine, sleep for a small period of time here
 	// to ensure that the goroutine has time to consume the channel
-	time.Sleep(100 * time.Microsecond)
+	time.Sleep(1 * time.Millisecond)
 	require.Len(t, in, 0)
 }


### PR DESCRIPTION
Adds a `Unique` function which returns a channel with batches of unique values.  `UniqueValues` and `UniqueKeyed` are included, providing additional functionality to channel sinks and determine uniqueness for complex types.

Also includes a bit of cleanup - updating some test requirements from Greater to GreaterOrEqual and adding some arguments to `Batch` signatures in the readme.